### PR TITLE
Improved Java Solution for "Balanced Binary Tree"

### DIFF
--- a/java/110-Balanced-Binary-Tree.java
+++ b/java/110-Balanced-Binary-Tree.java
@@ -1,0 +1,19 @@
+package com.coding.patterns.tree;
+
+class BalancedBinaryTree {
+    private static Pair<Boolean, Integer> dfs(TreeNode root) {
+        if (root == null) {
+            return new Pair<Boolean, Integer>(true, 0);
+        }
+        
+        var left = dfs(root.left);
+        var right = dfs(root.right);
+        
+        var balanced = left.getKey() && right.getKey() && (Math.abs(left.getValue() - right.getValue()) <= 1);
+        
+        return new Pair<Boolean, Integer>(balanced, 1 + Math.max(left.getValue(), right.getValue()));
+    }
+    public static boolean isBalanced(TreeNode root) {
+        return dfs(root).getKey();
+    }
+}


### PR DESCRIPTION
The following is a proposed improved solution in Java for Balanced Binary Tree.

I choose to use a Java Pair (somewhat different from C# Tuples - see how I did in C# https://github.com/irlcatgirl/Leetcode-BalancedBinaryTree-CS/blob/main/Solution.cs). I think the `.getKey()` and `.getValue()` does impact readability a bit although I think it's a little better than the alternative. Perhaps we could return a set or array but I'm concerned with the memory usage from that. My goal here was to maximize code readability, I'm not sure if this accomplishes that or makes the problem worse so consider this a feedback stage.

**Stats**

Runtime: 3 ms, faster than 8.81% of Java online submissions for Balanced Binary Tree. (I don't think I can beat 3ms but if you can let me know)

Memory Usage: 45.2 MB, less than 9.73% of Java online submissions for Balanced Binary Tree. (I think memory usage is what it is, but feel free to show alternatives with a DFS).