### PR TITLE
Unnecessary multiplication by 3 creates confusion

### DIFF
--- a/java/36-valid-sudoku.java
+++ b/java/36-valid-sudoku.java
@@ -15,10 +15,10 @@ class Solution {
                 
                 
                 //Check whether Box contains duplicate elements in it
-                if(h1.contains("box"+ (i/3)*3 + j/3 + board[i][j])){
+                if(h1.contains("box"+ (i/3) + (j/3) + board[i][j])){
                     return false;
                 }
-                h1.add("box"+ (i/3)*3 + j/3 + board[i][j]);
+                h1.add("box"+ (i/3) + (j/3) + board[i][j]);
                 }
             }
         }


### PR DESCRIPTION
Dividing i and j by 3 respectively is enough for creating a unique key for the box. The extra multiplication by 3 creates confusion as it is first of all not explained in the video explanation. And also unecessary.