### PR TITLE
Update 212-Word-Search-II.py

### DIFF
--- a/212-Word-Search-II.py
+++ b/212-Word-Search-II.py
@@ -2,14 +2,25 @@ class TrieNode:
     def __init__(self):
         self.children = {}
         self.isWord = False
+        self.refs = 0
         
     def addWord(self, word):
         cur = self
+        cur.refs += 1
         for c in word:
             if c not in cur.children:
                 cur.children[c] = TrieNode()
             cur = cur.children[c]
+            cur.refs += 1
         cur.isWord = True
+        
+    def removeWord(self, word):
+        cur = self
+        cur.refs -= 1
+        for c in word:
+            if c in cur.children:
+                cur = cur.children[c]
+                cur.refs -= 1
 
         
 class Solution:
@@ -24,14 +35,18 @@ class Solution:
         def dfs(r, c, node, word):
             if (r < 0 or c < 0 or 
                 r == ROWS or c == COLS or
-                board[r][c] not in node.children or (r, c) in visit):
+                board[r][c] not in node.children or
+                node.children[board[r][c]].refs < 1 or
+                (r, c) in visit):
                 return
             
             visit.add((r, c))
             node = node.children[board[r][c]]
             word += board[r][c]
             if node.isWord:
+                node.isWord = False
                 res.add(word)
+                root.removeWord(word)
             
             dfs(r + 1, c, node, word)
             dfs(r - 1, c, node, word)


### PR DESCRIPTION
Added following optimizations to bypass "Time Limit Exceeded":
1. when we add word, we can unmark node in trie to prevent redundant hashing checks in our words set. `node.isWord = false`
2. in the previous case we also should remove a word from the Trie. To prevent redundant heap deallocations, it's better to "mark" an Trie node using `refs` property. If `refs == 0`, then node is deleted.