### PR TITLE
remove redundant check

### DIFF
--- a/416-Partition-Equal-Subset-Sum.py
+++ b/416-Partition-Equal-Subset-Sum.py
@@ -15,4 +15,4 @@ class Solution:
                 nextDP.add(t + nums[i])
                 nextDP.add(t)
             dp = nextDP
-        return True if target in dp else False
+        return False


### PR DESCRIPTION
If target is in dp, it would have return because `(t + nums[i]) == target`.