### PR TITLE
Reduced complexity from O(2n) to O(n) for Leetcode 152- Max Product subarray

### DIFF
--- a/python/152-Maximum-Product-Subarray.py
+++ b/python/152-Maximum-Product-Subarray.py
@@ -1,7 +1,7 @@
 class Solution:
     def maxProduct(self, nums: List[int]) -> int:
         # O(n)/O(1) : Time/Memory
-        res = max(nums)
+        res = nums[0]
         curMin, curMax = 1, 1
 
         for n in nums:


### PR DESCRIPTION
Finding max using the max function in python has O(n) time complexity which adds unnecessary complexity

- **File(s) Modified**: _[152-Maximum-Product-Subarray.py]_
- **Language(s) Used**: _[python]_
- **Submission URL**: _[https://leetcode.com/submissions/detail/755481286/]_
