### PR TITLE
Fixes 139-Word-Break.js

### DIFF
--- a/javascript/139-Word-Break.js
+++ b/javascript/139-Word-Break.js
@@ -1,17 +1,15 @@
 let wordBreak = function (s, wordDict) {
-    let dp = new Array(s.length + 1);
-    dp.fill(false);
+    let dp = new Array(s.length + 1).fill(false);
     dp[s.length] = true;
 
-    let word = '';
     for (let i = s.length - 1; i >= 0; i--) {
-        word = s[i] + word;
-
-        if (wordDict.includes(word) && i + word.length < dp.length) {
-            dp[i] = dp[i + word.length];
-            word = '';
-        } else {
-            dp[i] = false;
+        for(let w of wordDict){
+            if (i + w.length <= s.length && s.substring(i, i + w.length) === w) {
+                dp[i] = dp[i + w.length];
+            }
+            if(dp[i]){
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
Fixes issue with the previous javascript word-break code. It fails for submission on leetcode.
- **Previous failed Submission URL**: _https://leetcode.com/submissions/detail/756676067/_

[//]: # "Pull Request Template"
[//]: # "Replace the placeholder values in the template below"

- **File(s) Modified**: _139-Word-Break.js_
- **Language(s) Used**: _javascript_
- **Submission URL**: _https://leetcode.com/submissions/detail/756667769/_

[//]: # "Getting the Submission URL"
[//]: # "Go to the leetcode [`Submissions tab`](https://user-images.githubusercontent.com/71089234/180188604-b1ecaf90-bf27-4fd6-a559-5567aebf8930.png)"
[//]: # "and [click on the `Accepted` status of your submission.](https://user-images.githubusercontent.com/71089234/180189321-1a48c33f-aa65-4b29-8aaa-685f4f5f8c9e.png)]"
[//]: # "Finally copy the URL from the nav bar, it should look like https://leetcode.com/submissions/detail/xxxxxxxxx/"
