### PR TITLE
Use unordered_map in C++ valid parentheses

### DIFF
--- a/cpp/neetcode_150/04_stack/valid_parentheses.cpp
+++ b/cpp/neetcode_150/04_stack/valid_parentheses.cpp
@@ -11,31 +11,14 @@
 class Solution {
 public:
     bool isValid(string s) {
-        stack<char> open;
-        
-        for (int i = 0; i < s.size(); i++) {
-            if (s[i] == ')' || s[i] == '}' || s[i] == ']') {
-                if (open.empty()) {
-                    return false;
-                }
-                if (s[i] == ')' && open.top() != '(') {
-                    return false;
-                }
-                if (s[i] == '}' && open.top() != '{') {
-                    return false;
-                }
-                if (s[i] == ']' && open.top() != '[') {
-                    return false;
-                }
-                open.pop();
-            } else {
-                open.push(s[i]);
-            }
+        stack<char> st;
+        unordered_map<char, char> pairs;
+        pairs['('] = ')';pairs['{'] = '}';pairs['['] = ']';
+        for(auto c : s){
+            if(pairs.find(c) != pairs.end()) st.push(c);
+            else if(st.size() != 0 and pairs[st.top()] == c) st.pop();
+            else return false;
         }
-        
-        if (!open.empty()) {
-            return false;
-        }
-        return true;
+        return st.size() == 0;
     }
 };


### PR DESCRIPTION
used unorderd_map in c++ solution of 20. Valid Parentheses (https://leetcode.com/problems/valid-parentheses) for storing the bracket pairs, hence minimizing the code length without any effect on runtime (still O(n)).

[//]: # "Pull Request Template"
[//]: # "Replace the placeholder values in the template below"

- **File(s) Modified**: _cpp/neetcode_150/04_stack/valid_parentheses.cpp_
- **Language(s) Used**: _cpp_
- **Submission URL**: _https://leetcode.com/submissions/detail/773246566/_

[//]: # "Getting the Submission URL"
[//]: # "Go to the leetcode [`Submissions tab`](https://user-images.githubusercontent.com/71089234/180188604-b1ecaf90-bf27-4fd6-a559-5567aebf8930.png)"
[//]: # "and [click on the `Accepted` status of your submission.](https://user-images.githubusercontent.com/71089234/180189321-1a48c33f-aa65-4b29-8aaa-685f4f5f8c9e.png)]"
[//]: # "Finally copy the URL from the nav bar, it should look like https://leetcode.com/submissions/detail/xxxxxxxxx/"
