### PR TITLE
Fix start/end attribute error for 252 Meeting Rooms.

### DIFF
--- a/python/252-Meeting-Rooms.py
+++ b/python/252-Meeting-Rooms.py
@@ -5,12 +5,12 @@ class Solution:
     """
 
     def canAttendMeetings(self, intervals):
-        intervals.sort(key=lambda i: i.start)
+        intervals.sort(key=lambda i: i[0])
 
         for i in range(1, len(intervals)):
             i1 = intervals[i - 1]
             i2 = intervals[i]
 
-            if i1.end > i2.start:
+            if i1[1] > i2[0]:
                 return False
         return True


### PR DESCRIPTION
[//]: # "Pull Request Template"
[//]: # "Replace the placeholder values in the template below"

- **File(s) Modified**: _252-Meeting-Rooms.py_
- **Language(s) Used**: _python_
- **Submission URL**: _https://leetcode.com/submissions/detail/787542121/_

[//]: # "Getting the Submission URL"
[//]: # "Go to the leetcode [`Submissions tab`](https://user-images.githubusercontent.com/71089234/180188604-b1ecaf90-bf27-4fd6-a559-5567aebf8930.png)"
[//]: # "and [click on the `Accepted` status of your submission.](https://user-images.githubusercontent.com/71089234/180189321-1a48c33f-aa65-4b29-8aaa-685f4f5f8c9e.png)]"
[//]: # "Finally copy the URL from the nav bar, it should look like https://leetcode.com/submissions/detail/xxxxxxxxx/"
