### PR TITLE
Modify Design-Add-and-Search-Words-Data-Structure.py: Revert cur.end to cur.word

### DIFF
--- a/python/211-Design-Add-and-Search-Words-Data-Structure.py
+++ b/python/211-Design-Add-and-Search-Words-Data-Structure.py
@@ -31,6 +31,6 @@ class WordDictionary:
                     if c not in cur.children:
                         return False
                     cur = cur.children[c]
-            return cur.end
+            return cur.word
 
         return dfs(0, self.root)


### PR DESCRIPTION
cur.end is not a property of class TrieNode. 
The correct property is cur.word

[//]: # "Pull Request Template"
[//]: # "Replace the placeholder values in the template below"

- **File(s) Modified**: _211-Design-Add-and-Search-Words-Data-Structure.py_
- **Language(s) Used**: _python3..._
- **Submission URL**: _https://leetcode.com/submissions/detail/830732890/_

