### PR TITLE
Fix 7-Reverse-Integer.py invalid conditions

### DIFF
--- a/python/7-Reverse-Integer.py
+++ b/python/7-Reverse-Integer.py
@@ -11,9 +11,9 @@ class Solution:
             digit = int(math.fmod(x, 10))  # (python dumb) -1 %  10 = 9
             x = int(x / 10)  # (python dumb) -1 // 10 = -1
 
-            if res > MAX // 10 or (res == MAX // 10 and digit >= MAX % 10):
+            if res > MAX // 10 or (res == MAX // 10 and digit > MAX % 10):
                 return 0
-            if res < MIN // 10 or (res == MIN // 10 and digit <= MIN % 10):
+            if res < MIN // 10 or (res == MIN // 10 and digit < MIN % 10):
                 return 0
             res = (res * 10) + digit
 


### PR DESCRIPTION
Fix two invalid conditions as for example (res == MAX // 10 and digit == MAX % 10) is actually valid and doesn't overflow, and we shouldn't be returning 0 in that case, similarly with the other condition

[//]: # "Pull Request Template"
[//]: # "Replace the placeholder values in the template below"

- **File(s) Modified**: _7-Reverse-Integer.py_
- **Language(s) Used**: _python_
- **Submission URL**: _https://leetcode.com/problems/reverse-integer/submissions/855342863/_

[//]: # "Getting the Submission URL"
[//]: # "Go to the leetcode [`Submissions tab`](https://user-images.githubusercontent.com/71089234/180188604-b1ecaf90-bf27-4fd6-a559-5567aebf8930.png)"
[//]: # "and [click on the `Accepted` status of your submission.](https://user-images.githubusercontent.com/71089234/180189321-1a48c33f-aa65-4b29-8aaa-685f4f5f8c9e.png)]"
[//]: # "Finally copy the URL from the nav bar, it should look like https://leetcode.com/submissions/detail/xxxxxxxxx/"
