### PR TITLE
Replace Kotlin solution for 90-Subsets-II with a more idiomatic and readable solution 

### DIFF
--- a/kotlin/90-Subsets-II.kt
+++ b/kotlin/90-Subsets-II.kt
@@ -1,21 +1,27 @@
 class Solution {
     fun subsetsWithDup(nums: IntArray): List<List<Int>> {
-        val res = mutableListOf<List<Int>>()
-        Arrays.sort(nums)
-        subsets(nums, 0, mutableListOf<Int>(), mutableSetOf<List<Int>>(), res)
-        return res
-    }
+        nums.sort()
+        val resultantList = mutableListOf<List<Int>>()
+        val intermediaryList = mutableListOf<Int>()
 
-    fun subsets(nums: IntArray, idx: Int, list: MutableList<Int>, set: MutableSet<List<Int>>, res: MutableList<List<Int>>) {
-        val copy = ArrayList(list)
+        fun dfs(decisionIndex: Int = 0) {
+            if (decisionIndex > nums.lastIndex) {
+                resultantList.add(intermediaryList.toList())
+                return
+            }
 
-        if (set.add(copy))
-            res.add(copy)
+            // decision to include nums[decisionIndex]
+            intermediaryList.add(nums[decisionIndex])
+            dfs(decisionIndex + 1)
 
-        for (i in idx..nums.size-1) {
-            list.add(nums[i])
-            subsets(nums, i+1, list, set, res)
-            list.removeAt(list.size-1)
+            // decision to not include nums[decisionIndex]
+            intermediaryList.removeAt(intermediaryList.lastIndex)
+            // skipping duplicates if any
+            var i = decisionIndex
+            while ((i in nums.indices && i + 1 in nums.indices) && nums[i] == nums[i + 1]) i++
+            dfs(i + 1)
         }
+        dfs()
+        return resultantList
     }
 }


### PR DESCRIPTION
…ble solution

[//]: # "Pull Request Template"
[//]: # "Replace the placeholder values in the template below"

- **File(s) Modified**: _90-Subsets-II.kt_
- **Language(s) Used**: _Kotlin._
- **Submission URL**: _https://leetcode.com/problems/subsets-ii/submissions/859477937/_

[//]: # "Getting the Submission URL"
[//]: # "Go to the leetcode [`Submissions tab`](https://user-images.githubusercontent.com/71089234/180188604-b1ecaf90-bf27-4fd6-a559-5567aebf8930.png)"
[//]: # "and [click on the `Accepted` status of your submission.](https://user-images.githubusercontent.com/71089234/180189321-1a48c33f-aa65-4b29-8aaa-685f4f5f8c9e.png)]"
[//]: # "Finally copy the URL from the nav bar, it should look like https://leetcode.com/submissions/detail/xxxxxxxxx/"
