### PR TITLE
Fix 0242-valid-anagram.rs

### DIFF
--- a/rust/0242-valid-anagram.rs
+++ b/rust/0242-valid-anagram.rs
@@ -6,11 +6,11 @@ impl Solution {
             return false;
         }
         
-        let mut map: HashMap<char, usize> = HashMap::new();
+        let mut map: HashMap<char, i64> = HashMap::new();
         
         for (a, b) in s.chars().zip(t.chars()){
-            *map.entry(a).or_default() +=1;
-            *map.entry(b).or_default() -=1;
+            *map.entry(a).or_default() += 1;
+            *map.entry(b).or_default() -= 1;
         }
         
         map.into_values().all(|cnt| cnt == 0)


### PR DESCRIPTION
Line 13 would cause an underflow on latest rustc 1.66.0, but not on leetcode. Changed to signed integer type to prevent underflow.
Submission URL: https://leetcode.com/problems/valid-anagram/submissions/870368270/
