### PR TITLE
Update 0347-top-k-frequent-elements.rs

### DIFF
--- a/rust/0347-top-k-frequent-elements.rs
+++ b/rust/0347-top-k-frequent-elements.rs
@@ -1,50 +1,29 @@
 use std::collections::HashMap;
-use std::cmp::Ordering;
 
 impl Solution {
     pub fn top_k_frequent(nums: Vec<i32>, k: i32) -> Vec<i32> {
-        let mut map: HashMap<i32, i32> = HashMap::new();
-        
-        for n in nums{
-            *map.entry(n).or_default() +=1;
-        }
-        
-        let mut freq: Vec<(i32, i32)> = map.into_iter().collect();
+        let mut count: HashMap<i32, i32> = HashMap::new();
+        let mut freq: Vec<Vec<i32>> = Vec::new();
+        freq.resize(nums.len() + 1, Vec::new());
 
-        let res = if k == freq.len() as i32{
-            &freq
-        }else{
-            quick_select(&mut freq, k)
-        };
-        
-        res.into_iter()
-        .map(|&(n, _)| n)
-        .collect()
-    }
-}
-
-pub fn quick_select(slice: &mut [(i32, i32)], k: i32) -> &[(i32, i32)]{
-    let (mut pivot, mut i, mut j) = (0, 1, 1);
-    
-    for index in 1..slice.len(){
-        if slice[index].1 >= slice[pivot].1{
-            slice.swap(index, j);
-            j+=1;
-        }else{
-            slice.swap(index, i);
-            i+=1;
-            j+=1;
+        for num in nums.into_iter() {
+            *count.entry(num).or_default() += 1;
         }
-    }
-    
-    slice.swap(pivot, i - 1);
-    pivot = i - 1;
-    
-    let larger_items = (j - pivot) as i32;
-    
-    match larger_items.cmp(&k) {
-        Ordering::Less => quick_select(&mut slice[0..j], k),
-        Ordering::Greater => quick_select(&mut slice[pivot + 1..j], k),
-        Ordering::Equal => &slice[pivot..j],
+
+        for (k, v) in count.into_iter() {
+            freq[v as usize].push(k);
+        }
+
+        let mut ret = Vec::new();
+        for v in freq.into_iter().rev() {
+            for item in v {
+                if ret.len() == k as usize {
+                    return ret
+                }
+                ret.push(item);
+            }
+        }
+
+        ret
     }
 }


### PR DESCRIPTION
My proposal for an updated solution. This is similar to the Python solution that is O(n) time. Partition/quick select algorithm is longer and harder to read.

Comparison of compiler output (my proposed solution has fewer instructions): Old: https://rust.godbolt.org/z/ofo3o8jT5
New: https://rust.godbolt.org/z/cTG38984T

- **File(s) Modified**: 0347-top-k-frequent-elements.rs
- **Language(s) Used**: rust
- **Submission URL**: https://leetcode.com/problems/top-k-frequent-elements/submissions/871042505/
