### PR TITLE
github: fix typo in pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 [//]: # "Pull Request Template"
 [//]: # "Replace the placeholder values in the template below"
 
-- **File(s) Modified**: 0001-two-sum.py, 0002-add-two-numbers.py, etc..._
+- **File(s) Modified**: _0001-two-sum.py, 0002-add-two-numbers.py, etc..._
 - **Language(s) Used**: _python, javascript, etc..._
 - **Submission URL**: _https://leetcode.com/problems/[problem-name]/submissions/xxxxxxxxx/_
 


### PR DESCRIPTION
PR template was missing an opening '_' for the File(s) Modified section.