### PR TITLE
fix: clean up 0338-counting-bits.c

### DIFF
--- a/c/0338-counting-bits.c
+++ b/c/0338-counting-bits.c
@@ -1,20 +1,23 @@
 /**
+ * Given an integer n, return an array ans of length n + 1 such that for each i
+ * (0 <= i <= n), ans[i] is the number of 1's in the binary representation of i.
+ *
+ * Constraints:
+ *
+ * 0 <= n <= 10^5
+ *
  * Note: The returned array must be malloced, assume caller calls free().
+ *
+ * Space: O(1)
+ * Time: O(n)
  */
-int* countBits(int n, int* returnSize){
-    // Initialize array of size n + 1
-    int arraySize = n + 1;
-    *returnSize = arraySize;
-    int *dp = (int *)malloc(sizeof(int)*arraySize);
-    memset(dp, 0, arraySize*sizeof(dp[0]));
-    int offset = 1;
-    
-    // Perform dp
-    for (int i = 1; i <= n; i++) {
-        if (offset * 2 == i) {
-            offset = i;
-        }
-        dp[i] = 1 + dp[i - offset];
-    }
-    return dp;
+
+int *countBits(int n, int *returnSize) {
+    int *ret = calloc(n + 1, sizeof(int));
+    *returnSize = n + 1;
+
+    for (int i = 1; i <= n; ++i)
+        ret[i] = ret[i >> 1] + (i & 1);
+
+    return ret;
 }


### PR DESCRIPTION
Use calloc() instead of malloc() and memset().
Use bit shifting instead of conditionally checking an offset.

[//]: # "Pull Request Template"
[//]: # "Replace the placeholder values in the template below"

- **File(s) Modified**: _0338-counting-bits.c_
- **Language(s) Used**: _c_
- **Submission URL**: _https://leetcode.com/problems/counting-bits/submissions/887746875/_

[//]: # "Getting the Submission URL"
[//]: # "Go to the leetcode [`Submissions tab`](https://user-images.githubusercontent.com/71089234/180188604-b1ecaf90-bf27-4fd6-a559-5567aebf8930.png)"
[//]: # "and [click on the `Accepted` status of your submission.](https://user-images.githubusercontent.com/71089234/180189321-1a48c33f-aa65-4b29-8aaa-685f4f5f8c9e.png)]"
[//]: # "Finally copy the URL from the nav bar, it should look like https://leetcode.com/problems/[problem-name]/submissions/xxxxxxxxx/"
