### PR TITLE
Bug fix: Defined as char however should be int - Java

### DIFF
--- a/java/0049-group-anagrams.java
+++ b/java/0049-group-anagrams.java
@@ -5,11 +5,11 @@ class Solution {
         if (strs.length == 0) return res;
         HashMap<String, List<String>> map = new HashMap<>();
         for (String s : strs) {
-            char[] hash = new char[26];
+            int[] hash = new int[26];
             for (char c : s.toCharArray()) {
                 hash[c - 'a']++;
             }
-            String key = new String(hash);
+            String key = new String(Arrays.toString(hash));
             map.computeIfAbsent(key, k -> new ArrayList<>());
             map.get(key).add(s);
         }


### PR DESCRIPTION
There was a small typo on Line 8 defining the array as char instead of int. This resulted in a permanent blank array as the ++ increment is an integer value and couldn't be stored.

[//]: # "Pull Request Template"
[//]: # "Replace the placeholder values in the template below"

- **File(s) Modified**: 0049-group-anagrams.java
- **Language(s) Used**: java
- **Submission URL**: https://leetcode.com/problems/group-anagrams/submissions/889250088/

### Important
Please make sure the file name is lowercase and a duplicate file does not already exist before merging.
