### PR TITLE
feat: Use faster algorithm for `python/0027-remove-element.py`

### DIFF
--- a/python/0027-remove-element.py
+++ b/python/0027-remove-element.py
@@ -5,6 +5,12 @@ class Solution(object):
         :type val: int
         :rtype: int
         """
-        for i in range(nums.count(val)):  # loop how many val is in the list
-            nums.remove(val)  # remove each val one by one
-        return len(nums)  # return len of nums
+        lptr = 0
+        for rptr in range(len(nums)):
+            if nums[rptr] == val:
+                continue
+            else:
+                nums[lptr] = nums[rptr]
+                lptr += 1
+
+        return lptr


### PR DESCRIPTION
This algorithm outperforms the current version at 30ms compared to 33ms runtime (though complexity is still `O(n)`). Memory efficiency is still the same. 

This algorithm also uses less Python-specific syntax and tricks and might be easier for engineers coming from other languages to read (though this is of course subjective).

The algorithm uses a 2-pointer approach (one pointer for insertion, `lptr`, and one pointer for lookup, `rptr`). Inspiration for approach came from a combination of the following 2 course videos:

1. https://www.youtube.com/watch?v=Pcd1ii9P9ZI
2. https://www.youtube.com/watch?v=DEJAZBq0FDA

- **File(s) Modified**: python/0027-remove-element.py
- **Language(s) Used**: python
- **Submission URL**: https://leetcode.com/problems/remove-element/solutions/3133218/beats-92-46/