### PR TITLE
Fix the sum bug on 0724-find-pivot-index.kt

### DIFF
--- a/kotlin/0724-find-pivot-index.kt
+++ b/kotlin/0724-find-pivot-index.kt
@@ -4,7 +4,7 @@ class Solution {
         var rightSum = 0
         for(num in nums) rightSum += num
         for(i in nums.indices){
-            if(leftSum == rightSum - nums[i]) return i
+            if(leftSum == rightSum - nums[i] - leftSum) return i
             leftSum += nums[i]
         }
         return -1


### PR DESCRIPTION
We have to minus the value with leftSum

[//]: # "Pull Request Template"
[//]: # "Replace the placeholder values in the template below"

- **File(s) Modified**:  _0724-find-pivot-index.kt_
- **Language(s) Used**: _kotlin_
- **Submission URL**: _https://leetcode.com/problems/find-pivot-index/submissions/909832132/_

[//]: # "Getting the Submission URL"
[//]: # "Go to the leetcode [`Submissions tab`](https://user-images.githubusercontent.com/71089234/180188604-b1ecaf90-bf27-4fd6-a559-5567aebf8930.png)"
[//]: # "and [click on the `Accepted` status of your submission.](https://user-images.githubusercontent.com/71089234/180189321-1a48c33f-aa65-4b29-8aaa-685f4f5f8c9e.png)]"
[//]: # "Finally copy the URL from the nav bar, it should look like https://leetcode.com/problems/[problem-name]/submissions/xxxxxxxxx/"


### Important
Please make sure the file name is lowercase and a duplicate file does not already exist before merging.
