### PR TITLE
Update 0021-merge-two-sorted-lists.rs

### DIFF
--- a/rust/0019-remove-nth-node-from-end-of-the-list.rs
+++ b/rust/0019-remove-nth-node-from-end-of-the-list.rs
@@ -1,0 +1,26 @@
+impl Solution {
+    pub fn remove_nth_from_end(head: Option<Box<ListNode>>, n: i32)-> Option<Box<ListNode>>  {
+     let mut list_len=0;
+     let mut cur=&head;
+     while let Some(node)=cur{
+         list_len+=1;
+         cur=&node.next;
+     }
+     let mut ans=Some(Box::new(ListNode{
+         val:1,
+         next:head
+     }));
+     let mut list=&mut ans;
+     let mut pos=0;
+     while let Some(node)=list{
+         if pos==list_len-n{
+             node.next=node.next.clone().unwrap().next.take();
+             break;
+         }
+         pos+=1;
+         list=&mut node.next;
+     }
+     ans.unwrap().next.take()
+    }
+}
+

--- a/rust/0021-merge-two-sorted-lists.rs
+++ b/rust/0021-merge-two-sorted-lists.rs
@@ -14,3 +14,31 @@ impl Solution {
         }
     }
 }
+//without recursion
+impl Solution {
+    pub fn merge_two_lists(mut list1: Option<Box<ListNode>>,mut list2: Option<Box<ListNode>>)->Option<Box<ListNode>>{
+        let mut ans=ListNode::new(1);
+        let mut cur=&mut ans;
+   
+   while let (Some(node1),Some(node2))=(list1.as_mut(),list2.as_mut()){
+   
+   if node1.val<node2.val{
+       cur.next=list1.take();
+       list1=cur.next.as_mut().unwrap().next.take();
+   }
+   else{
+       cur.next=list2.take();
+       list2=cur.next.as_mut().unwrap().next.take();
+   }
+   cur=cur.next.as_mut().unwrap();
+   }
+   cur.next=if list1.is_some(){
+       list1
+   }
+   else {
+       list2
+   };
+   ans.next
+}
+}
+


### PR DESCRIPTION
1)code without using recursion and with recursion for merge-two-sorted-list .All the test cases passed. Both the code are present in the same file one below another bottom one is without recursion (which was not present in the earlier one)

2)provided solution for 0019-remove-nth-node-from-end-of-the-list.rs which was not present earlier

[//]: # "Pull Request Template"
[//]: # "Replace the placeholder values in the template below"

- **File(s) Modified**: _0021-merge-two-sorted-list.rs_
- **Language(s) Used**: _rust_
- **Submission URL**: _https://leetcode.com/problems/merge-two-sorted-lists/submissions/922409088/_
 **File(s) Modified**: _0019-remove-nth-node-from-end-of-the-list.rs_
- **Language(s) Used**: _rust_
- **Submission URL**: _https://leetcode.com/problems/remove-nth-node-from-end-of-list/submissions/924077371/_

[//]: # "Getting the Submission URL"
[//]: # "Go to the leetcode [`Submissions tab`](https://user-images.githubusercontent.com/71089234/180188604-b1ecaf90-bf27-4fd6-a559-5567aebf8930.png)"
[//]: # "and [click on the `Accepted` status of your submission.](https://user-images.githubusercontent.com/71089234/180189321-1a48c33f-aa65-4b29-8aaa-685f4f5f8c9e.png)]"
[//]: # "Finally copy the URL from the nav bar, it should look like https://leetcode.com/problems/[problem-name]/submissions/xxxxxxxxx/"


### Important
Please make sure the file name is lowercase and a duplicate file does not already exist before merging.
