### PR TITLE
Skip usage of the 'visit' set. All you need is just add an extra condition

### DIFF
--- a/python/0286-walls-and-gates.py
+++ b/python/0286-walls-and-gates.py
@@ -6,7 +6,6 @@ class Solution:
 
     def walls_and_gates(self, rooms: List[List[int]]):
         ROWS, COLS = len(rooms), len(rooms[0])
-        visit = set()
         q = deque()
 
         def addRooms(r, c):
@@ -14,26 +13,24 @@ class Solution:
                 min(r, c) < 0
                 or r == ROWS
                 or c == COLS
-                or (r, c) in visit
                 or rooms[r][c] == -1
             ):
                 return
-            visit.add((r, c))
             q.append([r, c])
 
         for r in range(ROWS):
             for c in range(COLS):
                 if rooms[r][c] == 0:
                     q.append([r, c])
-                    visit.add((r, c))
 
         dist = 0
         while q:
             for i in range(len(q)):
                 r, c = q.popleft()
-                rooms[r][c] = dist
-                addRooms(r + 1, c)
-                addRooms(r - 1, c)
-                addRooms(r, c + 1)
-                addRooms(r, c - 1)
+                if rooms[r][c] >= dist:
+                    rooms[r][c] = dist
+                    addRooms(r + 1, c)
+                    addRooms(r - 1, c)
+                    addRooms(r, c + 1)
+                    addRooms(r, c - 1)
             dist += 1


### PR DESCRIPTION
You can skip usage of the 'visit' set. All you need is just add a condition 'if rooms[r][c] >= dist:' in line 34. It reduces memory usage as well as makes the code shorter.

