### PR TITLE
update python solution for LC 5 longest palindrome substring

### DIFF
--- a/python/0005-longest-palindromic-substring.py
+++ b/python/0005-longest-palindromic-substring.py
@@ -1,6 +1,6 @@
 class Solution:
     def longestPalindrome(self, s: str) -> str:
-        res = ""
+        start, end = float("-inf"), float("inf")
         resLen = 0
 
         for i in range(len(s)):
@@ -8,7 +8,7 @@ class Solution:
             l, r = i, i
             while l >= 0 and r < len(s) and s[l] == s[r]:
                 if (r - l + 1) > resLen:
-                    res = s[l : r + 1]
+                    start, end = l, r
                     resLen = r - l + 1
                 l -= 1
                 r += 1
@@ -17,9 +17,9 @@ class Solution:
             l, r = i, i + 1
             while l >= 0 and r < len(s) and s[l] == s[r]:
                 if (r - l + 1) > resLen:
-                    res = s[l : r + 1]
+                    start, end = l, r
                     resLen = r - l + 1
                 l -= 1
                 r += 1
 
-        return res
+        return s[start: end + 1]


### PR DESCRIPTION
**File Modified**: _0005-longest-palindromic-substring.py_
- **Language Used**: _python_
- **Submission URL**: _https://leetcode.com/problems/longest-palindromic-substring/submissions/945080908/_
-   **Reason**:
     - Optimizing the space complexity: the substring slice operation created extra space. Before O(N) extra space, after O(1) extra space. _(Please ignore this PR if the standard practice is to maintain the first solution exactly as the video in the youtube channel despite if it's not the most optimize approach.)_

### Important
Please make sure the file name is lowercase and a duplicate file does not already exist before merging.
