### PR TITLE
fix and simplify rust solution for `0036-valid-sudoku`

### DIFF
--- a/rust/0036-valid-sudoku.rs
+++ b/rust/0036-valid-sudoku.rs
@@ -12,28 +12,22 @@ impl Solution {
             for j in 0..9{
                 let r = board[i][j];
                 let c = board[j][i];
-                let b = board[i / 3 * 3 + j / 3][i/3 * 3 + j%3];
+                let b = board[i / 3 * 3 + j / 3][i % 3 * 3 + j % 3];
                 
                 if r != '.'{
-                    if !row.contains(&r){
-                        row.insert(r);
-                    }else{
+                    if !row.insert(r){
                         return false;
                     }
                 }
                 
                 if c != '.'{
-                    if !col.contains(&c){
-                        col.insert(c);
-                    }else{
+                    if !col.insert(c){
                         return false;
                     }
                 }
                 
                 if b != '.'{
-                    if !bx.contains(&b){
-                        bx.insert(b);
-                    }else{
+                    if !bx.insert(b){
                         return false;
                     }
                 }


### PR DESCRIPTION
- **File(s) Modified**: _0036-valid-sudoku.rs_
- **Language(s) Used**: _rust_
- **Submission URL**: _https://leetcode.com/problems/valid-sudoku/submissions/949636309/_

Previous incorrect submission: _https://leetcode.com/problems/valid-sudoku/submissions/949595521/_

1. fix for `bx` indices 
2. use of returned insertion status 
 
> **Note**
> _https://doc.rust-lang.org/std/collections/struct.HashSet.html#method.insert_
> If the set did not previously contain this value, `true` is returned.
> If the set already contained this value, `false` is returned.
