### PR TITLE
[Bugfix][valid-anagram] Fix wrong iteration of the smap

### DIFF
--- a/cpp/0242-valid-anagram.cpp
+++ b/cpp/0242-valid-anagram.cpp
@@ -13,8 +13,8 @@ public:
             tmap[t[i]]++;
         }
         
-        for(int i = 0; i < smap.size(); i++){
-            if(smap[i] != tmap[i]) return false;
+        for (auto &iter : smap) {
+            if (smap[iter.first] != tmap[iter.first]) return false;
         }
         return true;
     }


### PR DESCRIPTION
[//]: # "Pull Request Template"
[//]: # "Replace the placeholder values in the template below"

- **File(s) Modified**: _0242-valid-anagram.cpp_
- **Language(s) Used**: _C++_
- **Submission URL**: _https://leetcode.com/problems/valid-anagram/submissions/955359421/_

[//]: # "Getting the Submission URL"
[//]: # "Go to the leetcode [`Submissions tab`](https://user-images.githubusercontent.com/71089234/180188604-b1ecaf90-bf27-4fd6-a559-5567aebf8930.png)"
[//]: # "and [click on the `Accepted` status of your submission.](https://user-images.githubusercontent.com/71089234/180189321-1a48c33f-aa65-4b29-8aaa-685f4f5f8c9e.png)]"
[//]: # "Finally copy the URL from the nav bar, it should look like https://leetcode.com/problems/[problem-name]/submissions/xxxxxxxxx/"


### Change summary:
Using `smap[i]` where `0 < i < smap.size()` will insert the key `i` into the map if such key does not already exist ([link](https://en.cppreference.com/w/cpp/container/unordered_map/operator_at))
This is absolutely not what we want.
The fix is to iterate the smap, get the key and compare the value to tmap.