### PR TITLE
Update: 0105-Construct-Binary-Tree-From-Preorder-And-Inorder-Traversal

### DIFF
--- a/java/0105-construct-binary-tree-from-preorder-and-inorder-traversal.java
+++ b/java/0105-construct-binary-tree-from-preorder-and-inorder-traversal.java
@@ -14,32 +14,25 @@
  * }
  */
 class Solution {
-
     public TreeNode buildTree(int[] preorder, int[] inorder) {
-        if (preorder.length == 0 || inorder.length == 0) return null;
+        return build(Arrays.stream(preorder).boxed().toList(), Arrays.stream(inorder).boxed().toList());
+    }
 
-        TreeNode root = new TreeNode(preorder[0]);
-        int mid = 0;
-        for (int i = 0; i < inorder.length; i++) {
-            if (preorder[0] == inorder[i]) mid = i;
+    private TreeNode build(List<Integer> preorder, List<Integer> inorder) {
+        if (preorder.isEmpty()) {
+            return null;
         }
 
-        root.left =
-            buildTree(
-                Arrays.copyOfRange(preorder, 1, mid + 1),
-                Arrays.copyOfRange(inorder, 0, mid)
-            );
-        root.right =
-            buildTree(
-                Arrays.copyOfRange(preorder, mid + 1, preorder.length),
-                Arrays.copyOfRange(inorder, mid + 1, inorder.length)
-            );
+        final TreeNode root = new TreeNode(preorder.get(0));
+        final int mid = inorder.indexOf(preorder.get(0));
+        root.left = build(preorder.subList(1, mid + 1), inorder.subList(0, mid));
+        root.right = build(preorder.subList(mid + 1, preorder.size()), inorder.subList(mid + 1, inorder.size()));
 
-        return root;
+        return root; 
     }
 }
 
-// Solution without using Array copies
+// Solution without using lists.
 class Solution {
 
     Map<Integer, Integer> inorderPositions = new HashMap<>();


### PR DESCRIPTION
[//]: # "Pull Request Template"
[//]: # "Replace the placeholder values in the template below"

- **File(s) Modified**: _0105-construct-binary-tree-from-preorder-and-inorder-traversal.java_
- **Language(s) Used**: _java_
- **Submission URL**: _https://leetcode.com/problems/construct-binary-tree-from-preorder-and-inorder-traversal/submissions/1003061292/_

[//]: # "Getting the Submission URL"
[//]: # "Go to the leetcode [`Submissions tab`](https://user-images.githubusercontent.com/71089234/180188604-b1ecaf90-bf27-4fd6-a559-5567aebf8930.png)"
[//]: # "and [click on the `Accepted` status of your submission.](https://user-images.githubusercontent.com/71089234/180189321-1a48c33f-aa65-4b29-8aaa-685f4f5f8c9e.png)]"
[//]: # "Finally copy the URL from the nav bar, it should look like https://leetcode.com/problems/[problem-name]/submissions/xxxxxxxxx/"


### Important

Please make sure the file name is lowercase and a duplicate file does not already exist before merging.

### Changes

Modified solution to use sublists, which are backed by the original list, avoiding the linear-time copy from `copyOfRange`. New solution reads closer to the Python solution using slicing.
