### PR TITLE
Add more efficient solution to Longest Consecutive Sequence - Python

### DIFF
--- a/python/0128-longest-consecutive-sequence.py
+++ b/python/0128-longest-consecutive-sequence.py
@@ -12,17 +12,17 @@ class Solution:
                 longest = max(length, longest)
         return longest
     def longestConsecutiveNoRepeat(self, nums: List[int]) -> int:
-        s = set(nums)
-        res = 0 
-        while len(s) > 0:
+        numSet = set(nums)
+        longest = 0 
+        while len(numSet) > 0:
             cur = 0
-            i = s.pop()
-            s.add(i)
-            while i - 1 in s:
+            i = numSet.pop()
+            numSet.add(i)
+            while i - 1 in numSet:
                 i -= 1
-            while i in s:
-                s.remove(i)
+            while i in numSet:
+                numSet.remove(i)
                 cur += 1
                 i += 1
-            res = max(cur, res)
-        return res
+            longest = max(cur, longest)
+        return longest

--- a/python/0128-longest-consecutive-sequence.py
+++ b/python/0128-longest-consecutive-sequence.py
@@ -11,3 +11,18 @@ class Solution:
                     length += 1
                 longest = max(length, longest)
         return longest
+    def longestConsecutiveNoRepeat(self, nums: List[int]) -> int:
+        s = set(nums)
+        res = 0 
+        while len(s) > 0:
+            cur = 0
+            i = s.pop()
+            s.add(i)
+            while i - 1 in s:
+                i -= 1
+            while i in s:
+                s.remove(i)
+                cur += 1
+                i += 1
+            res = max(cur, res)
+        return res


### PR DESCRIPTION
[//]: # "Pull Request Template"
[//]: # "Replace the placeholder values in the template below"

- **File(s) Modified**: 0128-longest-consecutive-sequence.py
- **Language(s) Used**: Python
- **Submission URL**: [https://leetcode.com/problems/longest-consecutive-sequence/submissions/1009818489/](https://leetcode.com/problems/longest-consecutive-sequence/submissions/1009818489/)

I noticed that in the video solution, values were being repeatedly iterated over. Making my small change of iterating over the items remaining in the set rather than the entire array improves speed from 1500 ms to 350 ms. 

While they have the end up having the same Big O notation, I feel like it's a big enough speed improvement to include in the solutions. Since it differs from the video, I followed the contributing guidelines and added it as another method. I noticed the same problem in other languages and would be happy to update those in future PRs if this one goes through. 

My solution 
![Screenshot 2023-08-01 at 5 01 53 PM](https://github.com/neetcode-gh/leetcode/assets/21265120/3401bb37-51f7-4812-8949-885a518a2572)

Current solution
![Screenshot 2023-08-01 at 4 51 36 PM](https://github.com/neetcode-gh/leetcode/assets/21265120/2cc257e6-1e6f-460d-b9e6-cf635546621c)

