### PR TITLE
Add # as separator in key formulation

### DIFF
--- a/cpp/0049-group-anagrams.cpp
+++ b/cpp/0049-group-anagrams.cpp
@@ -31,8 +31,8 @@ private:
         }
         
         string key = "";
-        for (int i = 0; i < 26; i++) {
-            key.append(to_string(count[i] + 'a'));
+        for (int i = 0; i < count.size(); i++) {
+            key.append(to_string(count[i]) + '#');
         }
         return key;
     }


### PR DESCRIPTION
[//]: # "Pull Request Template"
[//]: # "Replace the placeholder values in the template below"

Note: The current getKey() function in the 0049-group-anagrams.cpp solution generates a key by adding 'a' to every character count before appending that sum to a string (e.g. to_string(count[i] + 'a')). While this happens to result in a correct solution when tested through Leetcode it is unclear why 'a' is used, and creates confusion for those reviewing the solution. In addition, this approach will likely break down if larger string sizes are allowed, as every entry in the key is numeric and there is no non-numeric separator. The correct approach is to use a clear separator in the string that is non-numeric between each count, such as '#'.

- **File(s) Modified**: 0049-group-anagrams.cpp
- **Language(s) Used**: C++
- **Submission URL**: https://leetcode.com/problems/group-anagrams/submissions/1014098378/

[//]: # "Getting the Submission URL"
[//]: # "Go to the leetcode [`Submissions tab`](https://user-images.githubusercontent.com/71089234/180188604-b1ecaf90-bf27-4fd6-a559-5567aebf8930.png)"
[//]: # "and [click on the `Accepted` status of your submission.](https://user-images.githubusercontent.com/71089234/180189321-1a48c33f-aa65-4b29-8aaa-685f4f5f8c9e.png)]"
[//]: # "Finally copy the URL from the nav bar, it should look like https://leetcode.com/problems/[problem-name]/submissions/xxxxxxxxx/"


### Important
Please make sure the file name is lowercase and a duplicate file does not already exist before merging.
