### PR TITLE
Update 0344-reverse-string.py. There is no need to use less-or-equal 

### DIFF
--- a/python/0344-reverse-string.py
+++ b/python/0344-reverse-string.py
@@ -5,7 +5,7 @@ class Solution:
         """
         l = 0
         r = len(s) - 1
-        while l <= r:
+        while l < r:
             s[l],s[r] = s[r],s[l]
             l += 1
             r -= 1


### PR DESCRIPTION
There is no need to use less-or-equal condition, substitute it with just 'less' condition.

- **File(s) Modified**:  0344-reverse-string.py
- **Language(s) Used**: python
- **Submission URL**: https://leetcode.com/problems/reverse-string/submissions/1028584240/

There is no need to use less-or-equal condition as in equal case 'l' and 'r' pointers are at the same letter. So there is no need to swap it.
Substitute the condition with just 'less' condition.
Simple correction but hope it helps as well.
