### PR TITLE
Update 0153-find-minimum-in-rotated-sorted-array.py

### DIFF
--- a/python/0153-find-minimum-in-rotated-sorted-array.py
+++ b/python/0153-find-minimum-in-rotated-sorted-array.py
@@ -1,18 +1,10 @@
 class Solution:
     def findMin(self, nums: List[int]) -> int:
-        start , end = 0 ,len(nums) - 1 
-        curr_min = float("inf")
-        
-        while start  <  end :
-            mid = (start + end ) // 2
-            curr_min = min(curr_min,nums[mid])
-            
-            # right has the min 
-            if nums[mid] > nums[end]:
-                start = mid + 1
-                
-            # left has the  min 
+        l, r = 0, len(nums) - 1
+        while l < r:
+            m = l + (r - l) // 2
+            if nums[m] > nums[r]:
+                l = m + 1
             else:
-                end = mid - 1 
-                
-        return min(curr_min,nums[start])
+                r = m
+        return nums[l]


### PR DESCRIPTION
- **File(s) Modified**: _0153-find-minimum-in-rotated-sorted-array.py_
- **Language(s) Used**: _python_
- **Submission URL**: _https://leetcode.com/problems/find-minimum-in-rotated-sorted-array/submissions/1033465730/_

This is faster as we only adjust the left and right pointers. In our else condition we assign r to m instead of m - 1. This is because it's possible that the min is m.

We always return nums[l].
You can try out edge cases to see why this always works.
