### PR TITLE
Prevent integer overflow in 0153-find-minimum-in-rotated-sorted-array.py

### DIFF
--- a/python/0153-find-minimum-in-rotated-sorted-array.py
+++ b/python/0153-find-minimum-in-rotated-sorted-array.py
@@ -4,7 +4,7 @@ class Solution:
         curr_min = float("inf")
         
         while start  <  end :
-            mid = (start + end ) // 2
+            mid = start + (end - start ) // 2
             curr_min = min(curr_min,nums[mid])
             
             # right has the min 


### PR DESCRIPTION
Prevent integer overflow in find minimum in rotated sorted array, python

[//]: # "Pull Request Template"
[//]: # "Replace the placeholder values in the template below"

- **File(s) Modified**: 0153-find-minimum-in-rotated-sorted-array.py
- **Language(s) Used**: Python
- **Submission URL**: https://leetcode.com/problems/find-minimum-in-rotated-sorted-array/submissions/1130122834/
