### PR TITLE
Update 0014-longest-common-prefix.py

### DIFF
--- a/python/0014-longest-common-prefix.py
+++ b/python/0014-longest-common-prefix.py
@@ -1,9 +1,7 @@
 class Solution:
     def longestCommonPrefix(self, strs: List[str]) -> str:
-        res = ""
         for i in range(len(strs[0])):
             for s in strs:
-                if i == len(s) or s[i] != strs[0][i]:
-                    return res
-            res += strs[0][i]
-        return res
+                if i >= len(s) or s[i] != strs[0][i]:
+                    return strs[0][:i]
+        return strs[0]


### PR DESCRIPTION
Optimizing the space by removing a variable for storing a prefix

- **File(s) Modified**: [0014-longest-common-prefix.py](https://github.com/neetcode-gh/leetcode/commit/7ee6b79d8191bb764e25ad9c217947e952f49a6f)
- **Language(s) Used**: Python
- **Submission URL**: [_https://leetcode.com/problems/[problem-name]/submissions/xxxxxxxxx/_](https://leetcode.com/problems/longest-common-prefix/submissions/1132757270)

**Notes**: 
- The space complexity is not discussed on the video. The space complexity of the original solution is O(k), where is **k** is the length of the prefix. However, there's no need to allocate additional space for storing this prefix, as it's already included within the first string. By directly returning `strs[0]` or `strs[0][:i]`, we effectively bring down the space complexity to O(1), which is constant.
- Regarding the time complexity, it could be considered as O(n * k), where is **n** is the number of strings in the `strs` and **k** is the length of the prefix.
