### PR TITLE
Handle time limit exceeded for 73rd test case

### DIFF
--- a/go/0128-longest-consecutive-sequence.go
+++ b/go/0128-longest-consecutive-sequence.go
@@ -23,6 +23,9 @@ func longestConsecutive(nums []int) int {
 		if sequence > res {
 			res = sequence
 		}
+		if res > len(nums)/2 {
+			break
+		}
 	}
 
 	return res


### PR DESCRIPTION
If result is already bigger than half of nums array means this res is the right answer and no other sequence can be bigger than current result

[//]: # "Pull Request Template"
[//]: # "Replace the placeholder values in the template below"

- **File(s) Modified**: _0128-longest-consecutive-sequence_
- **Language(s) Used**: _go_
- **Submission URL**: _[link](https://leetcode.com/problems/longest-consecutive-sequence/submissions/1133685424/)_

[//]: # "Getting the Submission URL"
[//]: # "Go to the leetcode [`Submissions tab`](https://user-images.githubusercontent.com/71089234/180188604-b1ecaf90-bf27-4fd6-a559-5567aebf8930.png)"
[//]: # "and [click on the `Accepted` status of your submission.](https://user-images.githubusercontent.com/71089234/180189321-1a48c33f-aa65-4b29-8aaa-685f4f5f8c9e.png)]"
[//]: # "Finally copy the URL from the nav bar, it should look like https://leetcode.com/problems/[problem-name]/submissions/xxxxxxxxx/"


### Important
Please make sure the file name is lowercase and a duplicate file does not already exist before merging.
