### PR TITLE
fix: Resolve memory leak in removeNthFromEnd function

### DIFF
--- a/c/0019-remove-nth-node-from-end-of-list.c
+++ b/c/0019-remove-nth-node-from-end-of-list.c
@@ -24,11 +24,15 @@ struct ListNode* removeNthFromEnd(struct ListNode* head, int n){
             slow = slow->next;
             fast = fast->next;
         }
-        slow->next = slow->next->next;
+        struct ListNode* tmp = slow->next;
+        slow->next = tmp->next;
+        free(tmp);
     }
     else {
         slow->val = slow->next->val;
-        slow->next = slow->next->next;
+        struct ListNode* tmp = slow->next;
+        slow->next = tmp->next;
+        free(tmp);
     }
     
     return head;


### PR DESCRIPTION
- **File(s) Modified**: c/0019-remove-nth-node-from-end-of-list.c
- **Language(s) Used**: C
- **Submission URL**: _[LeetCode Submission URL](https://leetcode.com/problems/remove-nth-node-from-end-of-list/submissions/1139256624)_

### Description of Changes
- Fixed a memory leak issue in the `removeNthFromEnd` function by properly freeing the removed node.
- Ensured that the function complies with the expected behavior and memory usage as per LeetCode's requirements.