### PR TITLE
Easier solution: 0049-group-anagrams.py

### DIFF
--- a/python/0049-group-anagrams.py
+++ b/python/0049-group-anagrams.py
@@ -1,5 +1,26 @@
 class Solution:
     def groupAnagrams(self, strs: List[str]) -> List[List[str]]:
+        groups = {}
+
+        # Iterate over strings
+        for s in strs: # O(m)
+            count = {}
+
+            # Count frequency of each character
+            for char in s: # O(n)
+                count[char] = count.get(char, 0) + 1
+
+            # Convert count Dict to List, sort it, and then convert to Tuple (we cannot use dicts or lists as keys in a hashmap)
+            tup = tuple(sorted(count.items())) # O(1) because there is limited amount of possible keys in the alphabet -> O(26) + O(26*log26) + O(26)
+
+            if tup in groups:
+                groups[tup].append(s)
+            else:
+                groups[tup] = [s] 
+            
+        return groups.values()
+    
+    def groupAnagrams(self, strs: List[str]) -> List[List[str]]:
         ans = collections.defaultdict(list)
 
         for s in strs:

--- a/python/0049-group-anagrams.py
+++ b/python/0049-group-anagrams.py
@@ -18,7 +18,7 @@ class Solution:
             else:
                 groups[tup] = [s] 
             
-        return groups.values()
+        return list(groups.values())
     
     def groupAnagrams(self, strs: List[str]) -> List[List[str]]:
         ans = collections.defaultdict(list)


### PR DESCRIPTION
I have written a more straightforward and easier to comprehend solution for problem "Group Anagrams", without compromising the BigO complexities.

Compared to Neetcode's version, this solution can take any type (and number) of different string characters as input and is not limited by 26 English characters. 

Instead of using an array to store character counts, we use a hashmap, however, it still eventually converts the counter hashmap to array form for sorting, and then to tuple. But these are all O(1) operations due to the limited number of possible keys (characters). We convert from Dict -> List + sort() -> Tuple to be able to use it as hashmap key.

More importantly, this way we also avoid the "clever" solution of using ASCII codes to modify the correct array index, as we only need to store the counts in a hashmap (like in the Easy "Valid Anagram" problem).

[//]: # "Pull Request Template"
[//]: # "Replace the placeholder values in the template below"

- **File(s) Modified**: 0049-group-anagrams.py
- **Language(s) Used**: python3
- **Submission URL**: https://leetcode.com/problems/group-anagrams/submissions/1266619221/

[//]: # "Getting the Submission URL"
[//]: # "Go to the leetcode [`Submissions tab`](https://user-images.githubusercontent.com/71089234/180188604-b1ecaf90-bf27-4fd6-a559-5567aebf8930.png)"
[//]: # "and [click on the `Accepted` status of your submission.](https://user-images.githubusercontent.com/71089234/180189321-1a48c33f-aa65-4b29-8aaa-685f4f5f8c9e.png)]"
[//]: # "Finally copy the URL from the nav bar, it should look like https://leetcode.com/problems/[problem-name]/submissions/xxxxxxxxx/"