### PR TITLE
Fix: Incorrect when dealing with UTF-8 chars > 1 byte

### DIFF
--- a/rust/0271-encode-and-decode-strings.rs
+++ b/rust/0271-encode-and-decode-strings.rs
@@ -9,7 +9,7 @@ impl Codec {
         let mut store = String::new();
         
         for s in strs{
-            let len = s.len() as u8;
+            let len = s.chars().count() as u8;
             
             store.push(len as char);
             store.push_str(&s);
@@ -31,7 +31,7 @@ impl Codec {
             
             if j <= s.len(){
                 let slice = &s[i..i + len];
-                res.push(slice.into_iter().collect::<String>());
+                res.push(slice.iter().collect::<String>());
             }
           
             i+=len;


### PR DESCRIPTION
Calling `.len()` on a `String` or `&str`  in rust returns the byte length. 

Also fixed the clippy lint.

[//]: # "Pull Request Template"
[//]: # "Replace the placeholder values in the template below"

- **File(s) Modified**: _0271-encode-and-decode-strings.rs_
- **Language(s) Used**: _rust_
- **Submission URL**: _https://github.com/WardLordRuby/leetcode-fix-rust-0271/commit/7808e8d313e640f052514c8e2826117ae74c5be6?diff=unified&w=1_

[//]: # "Getting the Submission URL"
[//]: # "Go to the leetcode [`Submissions tab`](https://user-images.githubusercontent.com/71089234/180188604-b1ecaf90-bf27-4fd6-a559-5567aebf8930.png)"
[//]: # "and [click on the `Accepted` status of your submission.](https://user-images.githubusercontent.com/71089234/180189321-1a48c33f-aa65-4b29-8aaa-685f4f5f8c9e.png)]"
[//]: # "Finally copy the URL from the nav bar, it should look like https://leetcode.com/problems/[problem-name]/submissions/xxxxxxxxx/"
