### PR TITLE
Fix suboptimal 242. valid-anagram c++ solution

### DIFF
--- a/cpp/0242-valid-anagram.cpp
+++ b/cpp/0242-valid-anagram.cpp
@@ -5,16 +5,18 @@ public:
     bool isAnagram(string s, string t) {
         if(s.size() != t.size()) return false;
         
-        unordered_map<char,int> smap;
-        unordered_map<char,int> tmap;
+        unordered_map<char, int> smap;
+        unordered_map<char, int> tmap;
         
         for(int i = 0; i < s.size(); i++){
             smap[s[i]]++;
             tmap[t[i]]++;
         }
-        
-        for(int i = 0; i < smap.size(); i++){
-            if(smap[i] != tmap[i]) return false;
+
+        for (auto const& [key, value] : smap) {
+          if (value != tmap[key]) {
+            return false;
+          }
         }
         return true;
     }


### PR DESCRIPTION
- **File(s) Modified**: _0242-valid-anagram.cpp_
- **Language(s) Used**: _C++_
- **Submission URL**: _https://leetcode.com/problems/valid-anagram/submissions/1361936517/_

The original solution passes, but unintentionally inserts ~100 elements into the hashmap because of this loop setup
```cpp
for (int i = 0; i < s.size(); i++)
  if (s_count[i] != t_count[i]) return false
```
Using ints as indices when the keys should be chars, it converts them to chars and continuously inserts into the map (due to using [operator \[\]](https://en.cppreference.com/w/cpp/container/unordered_map/operator_at)) until reaching the ascii range for lowercase letters (which is what the maps actually are supposed to store). Eventually the loop is able to end because all of keys that already exist in the hashmap are checked.

This new solution implements the original intended logic, directly comparing character counts between the two hashmaps rather than starting at index 0.