### PR TITLE
Update 1462-course-schedule-iv.py

### DIFF
--- a/python/1462-course-schedule-iv.py
+++ b/python/1462-course-schedule-iv.py
@@ -9,7 +9,7 @@ class Solution:
                 prereqMap[crs] = set()
                 for pre in adj[crs]:
                     prereqMap[crs] |= dfs(pre)
-            prereqMap[crs].add(crs)
+                    prereqMap[crs].add(pre)
             return prereqMap[crs]
 
         prereqMap = {} # map course -> set indirect prereqs


### PR DESCRIPTION
The prereqMap for a course `crs` does not need to contain the course itself which avoids updated to the set with visible impact on the performance results in Leetcode submision

- **File(s) Modified**: _1462-course-schedule-iv.py_
- **Language(s) Used**: _python_
- **Submission URL**: _https://leetcode.com/problems/course-schedule-iv/submissions/1373589237/_
