### PR TITLE
Update 0076-minimum-window-substring.py

### DIFF
--- a/python/0076-minimum-window-substring.py
+++ b/python/0076-minimum-window-substring.py
@@ -1,6 +1,6 @@
 class Solution:
     def minWindow(self, s: str, t: str) -> str:
-        if t == "":
+        if len(s) < len(t):
             return ""
 
         countT, window = {}, {}


### PR DESCRIPTION
The Leetcode description for the problem states:

```
m == s.length
n == t.length
1 <= m, n <= 10^5
```


Which means `t == ""` will never be True.

But what would make sense `if m < n => return ""`, because then we cant find a minimum window substring.

[//]: # "Pull Request Template"
[//]: # "Replace the placeholder values in the template below"

- **File(s) Modified**: 0076-minimum-window-substring.py
- **Language(s) Used**: python
- **Submission URL**: https://leetcode.com/problems/minimum-window-substring/submissions/1387425288/

