### PR TITLE
Refactor 0347-top-k-frequent-elements.go

### DIFF
--- a/go/0347-top-k-frequent-elements.go
+++ b/go/0347-top-k-frequent-elements.go
@@ -1,25 +1,20 @@
-func topKFrequent(nums []int, k int) (res []int) {
-	countMap := map[int]int{}
-	countSlice := make([][]int, len(nums)+1)
+func topKFrequent(nums []int, k int) []int {
+	var res []int
+	countMap := make(map[int]int)
+	countSliceLength := len(nums) + 1
+	countSlice := make([][]int, countSliceLength)
 
 	for _, num := range nums {
-		if count, ok := countMap[num]; ok {
-			countMap[num] = count + 1
-		} else {
-			countMap[num] = 1
-		}
+		countMap[num]++
 	}
 
 	for num, count := range countMap {
 		countSlice[count] = append(countSlice[count], num)
 	}
 
-	for i := len(countSlice) - 1; i > 0; i-- {
+	for i := countSliceLength - 1; len(res) != k; i-- {
 		res = append(res, countSlice[i]...)
-		if len(res) == k {
-			return
-		}
 	}
 
-	return
+	return res
 }


### PR DESCRIPTION
- **File(s) Modified**: go/0347-top-k-frequent-elements.go
- **Language(s) Used**: Go
- **Submission URL**: https://leetcode.com/problems/top-k-frequent-elements/submissions/1416811237/

1. The named return value in this case is confusing.
2. Fixed overhead in filling the countMap.
3. The built-in len function in Go for slices calculates on every call. It is best to store the result in a variable.
4. It is sufficient to check if len(res) != k in the for-loop condition.