### PR TITLE
Clarify log Time Complexity For `Search 2d Matrix` (LC 74)

### DIFF
--- a/articles/search-2d-matrix.md
+++ b/articles/search-2d-matrix.md
@@ -550,7 +550,7 @@ class Solution {
 
 ### Time & Space Complexity
 
-* Time complexity: $O(\log m + \log n)$
+* Time complexity: $O(\log m + \log n)$ (which reduces to $O(\log(m * n))$)
 * Space complexity: $O(1)$
 
 > Where $m$ is the number of rows and $n$ is the number of columns of matrix.


### PR DESCRIPTION
[//]: # "Pull Request Template"
[//]: # "Replace the placeholder values in the template below"

- **File(s) Modified**: articles/search-2d-matrix.md
- **Language(s) Used**: `md`
- **Submission URL**: N/A

I wanted to clarify that $O(\log m + \log n)$ reduces to $O(\log(m * n))$ as this is the same time complexity as the `Binary Search (One Pass)` approach. This might help in evaluating which to use during an interview.
