### PR TITLE
Update Python, Java, Go, Kotlin / 0155-minimum-stack.md 

### DIFF
--- a/articles/minimum-stack.md
+++ b/articles/minimum-stack.md
@@ -543,14 +543,14 @@ class MinStack:
         self.min = float('inf')
         self.stack = []
 
-    def push(self, x: int) -> None:
+    def push(self, val: int) -> None:
         if not self.stack:
             self.stack.append(0)
-            self.min = x
+            self.min = val
         else:
-            self.stack.append(x - self.min)
-            if x < self.min:
-                self.min = x
+            self.stack.append(val - self.min)
+            if val < self.min:
+                self.min = val
 
     def pop(self) -> None:
         if not self.stack:
@@ -581,13 +581,13 @@ public class MinStack {
         stack = new Stack<>();
     }
     
-    public void push(int x) {
+    public void push(int val) {
         if (stack.isEmpty()) {
             stack.push(0L);
-            min = x;
+            min = val;
         } else {
-            stack.push(x - min);
-            if (x < min) min = x;
+            stack.push(val - min);
+            if (val < min) min = val;
         }
     }
 
@@ -755,14 +755,14 @@ func Constructor() MinStack {
     }
 }
 
-func (this *MinStack) Push(x int) {
+func (this *MinStack) Push(val int) {
     if len(this.stack) == 0 {
         this.stack = append(this.stack, 0)
-        this.min = x
+        this.min = val
     } else {
-        this.stack = append(this.stack, x - this.min)
-        if x < this.min {
-            this.min = x
+        this.stack = append(this.stack, val - this.min)
+        if val < this.min {
+            this.min = val
         }
     }
 }
@@ -796,8 +796,8 @@ class MinStack() {
     private var min: Long = Long.MAX_VALUE
     private val stack = ArrayDeque<Long>()
 
-    fun push(x: Int) {
-        val valAsLong = x.toLong()
+    fun push(`val`: Int) {
+        val valAsLong = `val`.toLong()
         if (stack.isEmpty()) {
             stack.addLast(0L)
             min = valAsLong


### PR DESCRIPTION
**Where**
Neetcode > Roadmap > Stack > Min Stack > Solution > 3. One Stack

**Current**
All code templates on neetcode and leetcode (Python, Java, C++, JavaScript and C#) asked for ``val`` as the naming convention for the int input for the push function.

**Problem**
However for the solution "3. One Stack" Python, Java, Go & Kotlin input naming variable was called ``x``
Note on leetcode they ask for `val` in all relative code templates.

**Fix**
Python, Java & Go 3. One Stack solutions were updated to match variable naming in code template and other solutions to ``val`` 
Kotlin was updated to ```"`val`"``` (Ignore qoutations) where backticks needed escape reserved word. Also as per leetcode templates

All code has been tested on leetcode and confirmed working. solutions.

- **File(s) Modified**: _articles/minimum-stack.md_
- **Language(s) Used**: _Markdown_
- **Submission URL**: _https://neetcode.io/problems/minimum-stack_
