### PR TITLE
Fix articles/kth-smallest-integer-in-bst.md

### DIFF
--- a/articles/kth-smallest-integer-in-bst.md
+++ b/articles/kth-smallest-integer-in-bst.md
@@ -201,12 +201,13 @@ func kthSmallest(root *TreeNode, k int) int {
             return
         }
 
-        dfs(node.Left)
         arr = append(arr, node.Val)
+        dfs(node.Left)
         dfs(node.Right)
     }
 
     dfs(root)
+	sort.Ints(arr)
     return arr[k-1]
 }
 ```


### PR DESCRIPTION
[//]: # 'Pull Request Template'
[//]: # 'Replace the placeholder values in the template below'

- **File(s) Modified**:  `articles/kth-smallest-integer-in-bst.md`
- **Language(s) Used**:  _Go_
- **Submission URL**: _N/A (Documentation fix, not a code solution)_

Fixes #5330

### Description
Fixed the Go brute force solution that was using inorder traversal $(O(n))$.
Now collects all values and sorts them to achieve $O(n log n)$ time complexity, consistent with other language implementations.

[//]: # 'Getting the Submission URL'
[//]: # 'Go to the leetcode [`Submissions tab`](https://user-images.githubusercontent.com/71089234/180188604-b1ecaf90-bf27-4fd6-a559-5567aebf8930.png)'
[//]: # 'and [click on the `Accepted` status of your submission.](https://user-images.githubusercontent.com/71089234/180189321-1a48c33f-aa65-4b29-8aaa-685f4f5f8c9e.png)]'
[//]: # 'Finally copy the URL from the nav bar, it should look like https://leetcode.com/problems/[problem-name]/submissions/xxxxxxxxx/'

### Important

Please make sure the file name is lowercase and a duplicate file does not already exist before merging.
