### PR TITLE
Fix undefined: linkedliststack package issue

### DIFF
--- a/articles/binary-tree-diameter.md
+++ b/articles/binary-tree-diameter.md
@@ -925,6 +925,8 @@ public class Solution {
 ```
 
 ```go
+import "github.com/a234567894/gods/stacks/linkedliststack"
+
 /**
  * Definition for a binary tree node.
  * type TreeNode struct {

--- a/articles/minimum-stack.md
+++ b/articles/minimum-stack.md
@@ -222,6 +222,8 @@ public class MinStack {
 ```
 
 ```go
+import "github.com/a234567894/gods/stacks/linkedliststack"
+
 type MinStack struct {
     stack *linkedliststack.Stack
 }

--- a/articles/trapping-rain-water.md
+++ b/articles/trapping-rain-water.md
@@ -873,6 +873,8 @@ public class Solution {
 ```
 
 ```go
+import "github.com/a234567894/gods/stacks/linkedliststack"
+
 func trap(height []int) int {
     if len(height) == 0 {
         return 0

--- a/articles/validate-parentheses.md
+++ b/articles/validate-parentheses.md
@@ -512,6 +512,8 @@ public class Solution {
 ```
 
 ```go
+import "github.com/a234567894/gods/stacks/linkedliststack"
+
 func isValid(s string) bool {
     stack := linkedliststack.New()
     closeToOpen := map[rune]rune{')': '(', ']': '[', '}': '{'}


### PR DESCRIPTION
 - **File(s) Modified**: _articles/binary-tree-diameter.md, articles/minimum-stack.md, articles/trapping-rain-water.md, articles/validate-parentheses.md_
   - **Language(s) Used**: _go_
   - **Submission URL**: _https://neetcode.io/problems/validate-parentheses/solution_

   ### Summary

   Adds the missing `import "github.com/a234567894/gods/stacks/linkedliststack"` statement to Go code blocks in 4 article files where the `linkedliststack` package was used but not imported, causing an
   `undefined: linkedliststack` error.

   ### Files changed
   - `articles/validate-parentheses.md`
   - `articles/minimum-stack.md`
   - `articles/trapping-rain-water.md`
   - `articles/binary-tree-diameter.md`
