### PR TITLE
Remove update method from LFUCache class

### DIFF
--- a/articles/lfu-cache.md
+++ b/articles/lfu-cache.md
@@ -623,10 +623,6 @@ class LinkedList:
         self.pop(self.left.next.val)
         return res
 
-    def update(self, val):
-        self.pop(val)
-        self.pushRight(val)
-
 class LFUCache:
 
     def __init__(self, capacity: int):
@@ -719,11 +715,6 @@ class DoublyLinkedList {
         int res = this.left.next.val;
         pop(res);
         return res;
-    }
-
-    public void update(int val) {
-        pop(val);
-        pushRight(val);
     }
 }
 
@@ -843,11 +834,6 @@ class LFUCache {
             int res = left->next->val;
             pop(res);
             return res;
-        }
-
-        void update(int val) {
-            pop(val);
-            pushRight(val);
         }
     };
 
@@ -975,14 +961,6 @@ class LinkedList {
         const res = this.left.next.val;
         this.pop(res);
         return res;
-    }
-
-    /**
-     * @param {number} val
-     */
-    update(val) {
-        this.pop(val);
-        this.pushRight(val);
     }
 }
 


### PR DESCRIPTION
Removed the update method from LFUCache implementation in Python, Java, and JavaScript - `update()` is not called at all .

[//]: # 'Pull Request Template'
[//]: # 'Replace the placeholder values in the template below'

- **File(s) Modified**: `articles/lfu-cache.md`
- **Language(s) Used**: python, javascript,java
- **Submission URL**:  https://leetcode.com/problems/lfu-cache/submissions/1962889950/

[//]: # 'Getting the Submission URL'
[//]: # 'Go to the leetcode [`Submissions tab`](https://user-images.githubusercontent.com/71089234/180188604-b1ecaf90-bf27-4fd6-a559-5567aebf8930.png)'
[//]: # 'and [click on the `Accepted` status of your submission.](https://user-images.githubusercontent.com/71089234/180189321-1a48c33f-aa65-4b29-8aaa-685f4f5f8c9e.png)]'
[//]: # 'Finally copy the URL from the nav bar, it should look like https://leetcode.com/problems/[problem-name]/submissions/xxxxxxxxx/'

### Important

Please make sure the file name is lowercase and a duplicate file does not already exist before merging.
