### PR TITLE
Add ::tabs-start markers to ML articles for interactive code blocks

### DIFF
--- a/articles/backpropagation.md
+++ b/articles/backpropagation.md
@@ -37,6 +37,7 @@ We run the forward pass to get $\hat{y}$, compute the delta term (error times si
 
 ### Implementation
 
+::tabs-start
 ```python
 import numpy as np
 from numpy.typing import NDArray
@@ -57,6 +58,8 @@ class Solution:
 
         return (dL_dw, dL_db)
 ```
+::tabs-end
+
 
 ### Walkthrough
 
@@ -87,6 +90,7 @@ The negative gradients mean: increase $w_0$, increase $w_1$, and increase $b$ to
 
 The error is $\hat{y} - y$, not $y - \hat{y}$. Flipping it negates all gradients, making the model move away from the target.
 
+::tabs-start
 ```python
 # Wrong: inverted error
 error = y_true - y_hat
@@ -94,11 +98,14 @@ error = y_true - y_hat
 # Correct: prediction minus truth
 error = y_hat - y_true
 ```
+::tabs-end
+
 
 ### Forgetting the Sigmoid Derivative
 
 The sigmoid derivative is part of the chain. Without it, you are computing the gradient as if the activation were linear, which gives wrong weight updates.
 
+::tabs-start
 ```python
 # Wrong: missing sigmoid derivative in the chain
 delta = error  # only the error, no activation derivative
@@ -107,6 +114,8 @@ delta = error  # only the error, no activation derivative
 sigmoid_deriv = y_hat * (1.0 - y_hat)
 delta = error * sigmoid_deriv
 ```
+::tabs-end
+
 
 ---
 

--- a/articles/basics-of-pytorch.md
+++ b/articles/basics-of-pytorch.md
@@ -29,6 +29,7 @@ Each method exercises a core PyTorch operation. We use `torch.reshape` for resha
 
 ### Implementation
 
+::tabs-start
 ```python
 import torch
 import torch.nn
@@ -53,6 +54,8 @@ class Solution:
         loss = torch.nn.functional.mse_loss(prediction, target)
         return torch.round(loss, decimals=4)
 ```
+::tabs-end
+
 
 ### Walkthrough
 
@@ -76,6 +79,7 @@ class Solution:
 
 `dim=0` averages across rows (column-wise means), `dim=1` averages across columns (row-wise means). These are easy to confuse.
 
+::tabs-start
 ```python
 # Wrong: averages across columns instead of rows
 averaged = torch.mean(to_avg, dim=1)
@@ -83,11 +87,14 @@ averaged = torch.mean(to_avg, dim=1)
 # Correct: averages across rows (column means)
 averaged = torch.mean(to_avg, dim=0)
 ```
+::tabs-end
+
 
 ### Mismatched Shapes for Concatenation
 
 Concatenation along `dim=1` requires the same number of rows. Different row counts cause a runtime error.
 
+::tabs-start
 ```python
 # Wrong: different number of rows (2 vs 3)
 torch.cat((torch.zeros(2, 3), torch.zeros(3, 3)), dim=1)
@@ -95,6 +102,8 @@ torch.cat((torch.zeros(2, 3), torch.zeros(3, 3)), dim=1)
 # Correct: same number of rows
 torch.cat((torch.zeros(2, 3), torch.zeros(2, 3)), dim=1)
 ```
+::tabs-end
+
 
 ---
 

--- a/articles/build-vocabulary.md
+++ b/articles/build-vocabulary.md
@@ -32,6 +32,7 @@ Extract unique characters with `set()`, sort them, build two dictionaries with e
 
 ### Implementation
 
+::tabs-start
 ```python
 from typing import Dict, List, Tuple
 
@@ -48,6 +49,8 @@ class Solution:
     def decode(self, ids: List[int], itos: Dict[int, str]) -> str:
         return ''.join(itos[i] for i in ids)
 ```
+::tabs-end
+
 
 ### Walkthrough
 
@@ -77,6 +80,7 @@ Round-trip: `decode(encode("hello")) = "hello"`.
 
 Python sets have no guaranteed iteration order. Without sorting, the same text may produce different vocabularies on different runs.
 
+::tabs-start
 ```python
 # Wrong: non-deterministic order
 chars = list(set(text))
@@ -84,11 +88,14 @@ chars = list(set(text))
 # Correct: sorted for reproducibility
 chars = sorted(set(text))
 ```
+::tabs-end
+
 
 ### Building itos Incorrectly
 
 The `itos` mapping must be the exact inverse of `stoi`. Building it independently can introduce mismatches.
 
+::tabs-start
 ```python
 # Wrong: building independently, might not be exact inverse
 itos = {i: ch for i, ch in enumerate(chars)}
@@ -96,6 +103,8 @@ itos = {i: ch for i, ch in enumerate(chars)}
 # Correct: derive from stoi to guarantee inverse relationship
 itos = {i: ch for ch, i in stoi.items()}
 ```
+::tabs-end
+
 
 ---
 

--- a/articles/code-gpt.md
+++ b/articles/code-gpt.md
@@ -33,6 +33,7 @@ Compose all previously built components: embedding layers, a sequence of transfo
 
 ### Implementation
 
+::tabs-start
 ```python
 import torch
 import torch.nn as nn
@@ -135,6 +136,8 @@ class GPT(nn.Module):
             embedded = embedded + self.linear_network(self.second_norm(embedded)) # another skip connection
             return embedded
 ```
+::tabs-end
+
 
 ### Walkthrough
 
@@ -166,6 +169,7 @@ Each of the 5 positions outputs a distribution over 100 tokens, predicting the n
 
 Without position embeddings, the model has no way to distinguish "cat sat" from "sat cat." The representations would be identical.
 
+::tabs-start
 ```python
 # Wrong: no position information
 embedded = self.word_embeddings(context)
@@ -177,11 +181,14 @@ positions = torch.arange(context.shape[1], device=context.device)
 embedded = embedded + self.position_embeddings(positions)
 output = self.transformer_blocks(embedded)
 ```
+::tabs-end
+
 
 ### Using nn.ModuleList Instead of nn.Sequential for Blocks
 
 `nn.Sequential` chains modules automatically in `forward`. `nn.ModuleList` requires you to write the loop yourself. Both register parameters, but Sequential is cleaner here.
 
+::tabs-start
 ```python
 # Works but requires manual loop
 self.blocks = nn.ModuleList([TransformerBlock(...) for _ in range(N)])
@@ -191,6 +198,8 @@ self.blocks = nn.ModuleList([TransformerBlock(...) for _ in range(N)])
 self.blocks = nn.Sequential(*[TransformerBlock(...) for _ in range(N)])
 # forward: x = self.blocks(x)
 ```
+::tabs-end
+
 
 ---
 

--- a/articles/cross-entropy-loss.md
+++ b/articles/cross-entropy-loss.md
@@ -36,6 +36,7 @@ For binary cross-entropy, we apply the formula directly: clip predictions with e
 
 ### Implementation
 
+::tabs-start
 ```python
 import numpy as np
 from numpy.typing import NDArray
@@ -55,6 +56,8 @@ class Solution:
         loss = -np.mean(np.sum(y_true * np.log(y_pred), axis=1))
         return round(loss, 4)
 ```
+::tabs-end
+
 
 ### Walkthrough
 
@@ -90,6 +93,7 @@ Average: $(0.35667 + 0.22314) / 2 = 0.28991$
 
 Without epsilon clipping, $\log(0)$ produces $-\infty$ and breaks training.
 
+::tabs-start
 ```python
 # Wrong: log(0) is undefined
 loss = -np.mean(y_true * np.log(y_pred))
@@ -98,11 +102,14 @@ loss = -np.mean(y_true * np.log(y_pred))
 y_pred = np.clip(y_pred, 1e-7, 1 - 1e-7)
 loss = -np.mean(y_true * np.log(y_pred))
 ```
+::tabs-end
+
 
 ### Mixing Up Binary and Categorical
 
 Binary cross-entropy expects 1D arrays (one probability per sample). Categorical expects 2D arrays (one probability per class per sample). Using the wrong one silently produces wrong gradients.
 
+::tabs-start
 ```python
 # Wrong: using BCE formula on one-hot encoded multi-class data
 loss = -np.mean(y_true * np.log(y_pred) + (1 - y_true) * np.log(1 - y_pred))
@@ -110,6 +117,8 @@ loss = -np.mean(y_true * np.log(y_pred) + (1 - y_true) * np.log(1 - y_pred))
 # Correct: for multi-class, sum over classes first, then average over samples
 loss = -np.mean(np.sum(y_true * np.log(y_pred), axis=1))
 ```
+::tabs-end
+
 
 ---
 

--- a/articles/gpt-data-loader.md
+++ b/articles/gpt-data-loader.md
@@ -32,6 +32,7 @@ Sample random starting indices with `torch.randint`, then for each index use ten
 
 ### Implementation
 
+::tabs-start
 ```python
 import torch
 from torchtyping import TensorType
@@ -45,6 +46,8 @@ class Solution:
         y = torch.stack([data[i + 1:i + 1 + context_length] for i in ix])
         return x, y
 ```
+::tabs-end
+
 
 ### Walkthrough
 
@@ -73,6 +76,7 @@ At position 0 of batch 0, the model sees $[20]$ and must predict $30$. At positi
 
 If you sample from $[0, \text{len}(\text{data}))$ instead of $[0, \text{len}(\text{data}) - C)$, starting positions near the end will cause index-out-of-bounds when extracting the target window.
 
+::tabs-start
 ```python
 # Wrong: index can be too large, y slice goes past end
 ix = torch.randint(len(data), (batch_size,))
@@ -80,11 +84,14 @@ ix = torch.randint(len(data), (batch_size,))
 # Correct: ensure room for context_length + 1 tokens
 ix = torch.randint(len(data) - context_length, (batch_size,))
 ```
+::tabs-end
+
 
 ### Forgetting the +1 Offset for Targets
 
 The target window starts one position after the input window. Without the offset, input and target are identical and the model learns nothing.
 
+::tabs-start
 ```python
 # Wrong: target same as input
 y = torch.stack([data[i:i + context_length] for i in ix])
@@ -92,6 +99,8 @@ y = torch.stack([data[i:i + context_length] for i in ix])
 # Correct: target shifted by 1
 y = torch.stack([data[i + 1:i + 1 + context_length] for i in ix])
 ```
+::tabs-end
+
 
 ---
 

--- a/articles/gpt-dataset.md
+++ b/articles/gpt-dataset.md
@@ -33,6 +33,7 @@ Split the raw text into words, sample random starting positions, and extract con
 
 ### Implementation
 
+::tabs-start
 ```python
 import torch
 from typing import List, Tuple
@@ -49,6 +50,8 @@ class Solution:
             Y.append(tokenized[idx+1:idx+1+context_length])
         return X, Y
 ```
+::tabs-end
+
 
 ### Walkthrough
 
@@ -77,6 +80,7 @@ Each target word is the next word after the corresponding input position.
 
 The problem uses `torch.manual_seed(0)` for reproducibility. Using `random.randint` instead produces different indices and fails the test cases.
 
+::tabs-start
 ```python
 # Wrong: different RNG, non-reproducible
 import random
@@ -87,11 +91,14 @@ indices = [random.randint(0, len(tokenized) - context_length - 1) for _ in range
 torch.manual_seed(0)
 indices = torch.randint(low=0, high=len(tokenized) - context_length, size=(batch_size,)).tolist()
 ```
+::tabs-end
+
 
 ### Forgetting to Convert Tensor Indices to Python List
 
 `torch.randint` returns a tensor. Using it directly for list slicing works, but `.tolist()` makes the code clearer and avoids potential type issues.
 
+::tabs-start
 ```python
 # Works but less clear
 indices = torch.randint(low=0, high=n, size=(batch_size,))
@@ -101,6 +108,8 @@ for idx in indices:
 # Better: explicit conversion
 indices = torch.randint(low=0, high=n, size=(batch_size,)).tolist()
 ```
+::tabs-end
+
 
 ---
 

--- a/articles/gradient-descent.md
+++ b/articles/gradient-descent.md
@@ -29,6 +29,7 @@ We start at some initial value and repeatedly apply the update rule. Each iterat
 
 ### Implementation
 
+::tabs-start
 ```python
 class Solution:
     def get_minimizer(self, iterations: int, learning_rate: float, init: int) -> float:
@@ -40,6 +41,8 @@ class Solution:
 
         return round(minimizer, 5)
 ```
+::tabs-end
+
 
 ### Walkthrough
 
@@ -66,6 +69,7 @@ Each step multiplies $x$ by $(1 - 2\alpha) = 0.8$, so convergence is geometric.
 
 A common mistake is computing the derivative but not actually subtracting it from the current value:
 
+::tabs-start
 ```python
 # Wrong: derivative computed but minimizer never changes
 derivative = 2 * minimizer
@@ -75,6 +79,8 @@ derivative = 2 * minimizer
 derivative = 2 * minimizer
 minimizer = minimizer - learning_rate * derivative
 ```
+::tabs-end
+
 
 ### Using the Wrong Derivative
 

--- a/articles/handwritten-digit-classifier.md
+++ b/articles/handwritten-digit-classifier.md
@@ -34,6 +34,7 @@ We define a PyTorch `nn.Module` with two linear layers, ReLU, dropout, and sigmo
 
 ### Implementation
 
+::tabs-start
 ```python
 import torch
 import torch.nn as nn
@@ -58,6 +59,8 @@ class Solution(nn.Module):
         x = self.sigmoid(x)
         return torch.round(x, decimals=4)
 ```
+::tabs-end
+
 
 ### Walkthrough
 
@@ -86,6 +89,7 @@ The output is 10 values, each representing the model's confidence for a digit. T
 
 Without `torch.manual_seed(0)`, weight initialization and dropout patterns are random, making the output non-deterministic and tests fail.
 
+::tabs-start
 ```python
 # Wrong: non-deterministic initialization
 def __init__(self):
@@ -98,11 +102,14 @@ def __init__(self):
     torch.manual_seed(0)
     self.first_linear = nn.Linear(784, 512)
 ```
+::tabs-end
+
 
 ### Using Softmax Instead of Sigmoid
 
 Softmax produces a distribution that sums to 1 (probabilities are coupled). Sigmoid produces independent probabilities for each class. The problem specifies sigmoid.
 
+::tabs-start
 ```python
 # Wrong: softmax couples the outputs
 x = nn.functional.softmax(x, dim=-1)
@@ -110,6 +117,8 @@ x = nn.functional.softmax(x, dim=-1)
 # Correct: sigmoid gives independent per-class probabilities
 x = self.sigmoid(x)
 ```
+::tabs-end
+
 
 ---
 

--- a/articles/layer-normalization.md
+++ b/articles/layer-normalization.md
@@ -33,6 +33,7 @@ Compute the mean and variance of the input, subtract the mean, divide by the sta
 
 ### Implementation
 
+::tabs-start
 ```python
 import numpy as np
 from numpy.typing import NDArray
@@ -47,6 +48,8 @@ class Solution:
         out = gamma * x_norm + beta
         return np.round(out, 5)
 ```
+::tabs-end
+
 
 ### Walkthrough
 
@@ -75,6 +78,7 @@ With $\gamma = [2, 2, 2, 2]$ and $\beta = [1, 1, 1, 1]$, the output would be $[-
 
 Without epsilon, a constant input (all same values) has variance 0, causing division by zero.
 
+::tabs-start
 ```python
 # Wrong: division by zero when variance is 0
 x_norm = (x - mean) / np.sqrt(var)
@@ -82,11 +86,14 @@ x_norm = (x - mean) / np.sqrt(var)
 # Correct: epsilon prevents division by zero
 x_norm = (x - mean) / np.sqrt(var + 1e-5)
 ```
+::tabs-end
+
 
 ### Using Batch Statistics Instead of Per-Sample Statistics
 
 Layer norm computes mean and variance per sample. If you accidentally compute statistics across the batch dimension, you get batch normalization instead.
 
+::tabs-start
 ```python
 # Wrong for layer norm: statistics across batch
 mean = np.mean(x, axis=0)  # this is batch norm
@@ -94,6 +101,8 @@ mean = np.mean(x, axis=0)  # this is batch norm
 # Correct for layer norm: statistics across features (within each sample)
 mean = np.mean(x)  # for a single sample vector
 ```
+::tabs-end
+
 
 ---
 

--- a/articles/linear-regression-forward.md
+++ b/articles/linear-regression-forward.md
@@ -31,6 +31,7 @@ The forward pass is a single matrix-vector multiplication using `np.matmul`. The
 
 ### Implementation
 
+::tabs-start
 ```python
 import numpy as np
 from numpy.typing import NDArray
@@ -45,6 +46,8 @@ class Solution:
         error = np.mean(np.square(model_prediction - ground_truth))
         return round(error, 5)
 ```
+::tabs-end
+
 
 ### Walkthrough
 
@@ -71,6 +74,7 @@ MSE $= (0.25 + 2.25 + 0.25) / 3 = 0.91667$
 
 `X * w` broadcasts and multiplies element-wise, which is not the dot product you want.
 
+::tabs-start
 ```python
 # Wrong: element-wise multiplication, wrong shape
 prediction = X * weights
@@ -78,11 +82,14 @@ prediction = X * weights
 # Correct: matrix-vector multiplication
 prediction = np.matmul(X, weights)
 ```
+::tabs-end
+
 
 ### Forgetting to Square Before Averaging
 
 Mean absolute error and mean squared error are different loss functions with different gradient properties.
 
+::tabs-start
 ```python
 # Wrong: this is MAE, not MSE
 error = np.mean(np.abs(model_prediction - ground_truth))
@@ -90,6 +97,8 @@ error = np.mean(np.abs(model_prediction - ground_truth))
 # Correct: MSE squares the differences
 error = np.mean(np.square(model_prediction - ground_truth))
 ```
+::tabs-end
+
 
 ---
 

--- a/articles/linear-regression-training.md
+++ b/articles/linear-regression-training.md
@@ -34,6 +34,7 @@ At each iteration, compute predictions with current weights, compute the gradien
 
 ### Implementation
 
+::tabs-start
 ```python
 import numpy as np
 from numpy.typing import NDArray
@@ -64,6 +65,8 @@ class Solution:
 
         return np.round(initial_weights, 5)
 ```
+::tabs-end
+
 
 ### Walkthrough
 
@@ -92,6 +95,7 @@ After more iterations, the weights converge toward the true relationship $y = 1x
 
 If you recompute predictions inside the inner weight loop, each weight sees a different prediction vector. Compute predictions once per iteration, then update all weights.
 
+::tabs-start
 ```python
 # Wrong: recomputing predictions after each weight update
 for j in range(len(weights)):
@@ -105,11 +109,14 @@ for j in range(len(weights)):
     gradient = self.get_derivative(prediction, Y, N, X, j)
     weights[j] -= gradient * lr
 ```
+::tabs-end
+
 
 ### Getting the Gradient Sign Wrong
 
 The derivative formula has a negative sign because we compute $(y - \hat{y})$, not $(\hat{y} - y)$. Flipping the sign makes the model diverge instead of converge.
 
+::tabs-start
 ```python
 # Wrong: wrong sign, model diverges
 return 2 * np.dot(ground_truth - model_prediction, X[:, j]) / N
@@ -117,6 +124,8 @@ return 2 * np.dot(ground_truth - model_prediction, X[:, j]) / N
 # Correct: negative sign
 return -2 * np.dot(ground_truth - model_prediction, X[:, j]) / N
 ```
+::tabs-end
+
 
 ---
 

--- a/articles/make-gpt-talk-back.md
+++ b/articles/make-gpt-talk-back.md
@@ -36,6 +36,7 @@ Loop for the desired number of characters. Each iteration: crop context if neede
 
 ### Implementation
 
+::tabs-start
 ```python
 import torch
 import torch.nn as nn
@@ -65,6 +66,8 @@ class Solution:
             result.append(int_to_char[next_token.item()])
         return ''.join(result)
 ```
+::tabs-end
+
 
 ### Walkthrough
 
@@ -92,6 +95,7 @@ Result: `"ello"`. Once the context grows past 8 tokens, it would be cropped to t
 
 Without cropping, the context grows past the model's maximum length, causing position embedding index errors.
 
+::tabs-start
 ```python
 # Wrong: context grows indefinitely
 logits = model(context)  # crashes when context > context_length
@@ -101,11 +105,14 @@ if context.shape[1] > context_length:
     context = context[:, -context_length:]
 logits = model(context)
 ```
+::tabs-end
+
 
 ### Using Argmax Instead of Sampling
 
 Greedy decoding (argmax) produces deterministic but often repetitive text. The problem expects sampling with `torch.multinomial`.
 
+::tabs-start
 ```python
 # Wrong: deterministic, repetitive output
 next_token = torch.argmax(probs, dim=-1, keepdim=True)
@@ -113,11 +120,14 @@ next_token = torch.argmax(probs, dim=-1, keepdim=True)
 # Correct: sampling introduces variety
 next_token = torch.multinomial(probs, 1, generator=generator)
 ```
+::tabs-end
+
 
 ### Taking Logits from All Positions Instead of the Last
 
 The model outputs logits at every position, but only the last position predicts the next token. Using logits from other positions gives you predictions for tokens that already exist.
 
+::tabs-start
 ```python
 # Wrong: using all positions
 probs = nn.functional.softmax(logits, dim=-1)  # (1, T, V)
@@ -126,6 +136,8 @@ probs = nn.functional.softmax(logits, dim=-1)  # (1, T, V)
 last_logits = logits[:, -1, :]  # (1, V)
 probs = nn.functional.softmax(last_logits, dim=-1)
 ```
+::tabs-end
+
 
 ---
 

--- a/articles/mlp-from-scratch.md
+++ b/articles/mlp-from-scratch.md
@@ -30,6 +30,7 @@ We iterate through the list of weight matrices and bias vectors. For each layer,
 
 ### Implementation
 
+::tabs-start
 ```python
 import numpy as np
 from numpy.typing import NDArray
@@ -45,6 +46,8 @@ class Solution:
                 h = np.maximum(0, h)         # ReLU on hidden layers only
         return np.round(h, 5)
 ```
+::tabs-end
+
 
 ### Walkthrough
 
@@ -71,6 +74,7 @@ Notice that the negative value $-0.5$ was zeroed by ReLU. This sparsity is a fea
 
 The output layer should produce raw logits (for classification) or raw predictions (for regression). Applying ReLU to the output clips negative values, which prevents the model from predicting negative numbers.
 
+::tabs-start
 ```python
 # Wrong: ReLU on every layer including output
 for i in range(len(weights)):
@@ -83,11 +87,14 @@ for i in range(len(weights)):
     if i < len(weights) - 1:
         h = np.maximum(0, h)
 ```
+::tabs-end
+
 
 ### Shape Mismatches in Weight Matrices
 
 Each weight matrix must have its input dimension matching the previous layer's output dimension. A shape $(3, 4)$ weight matrix expects 3-dimensional input and produces 4-dimensional output.
 
+::tabs-start
 ```python
 # Wrong: weights[1] has incompatible input dimension
 weights = [np.zeros((2, 3)), np.zeros((4, 1))]  # 3 != 4
@@ -95,6 +102,8 @@ weights = [np.zeros((2, 3)), np.zeros((4, 1))]  # 3 != 4
 # Correct: output dim of layer i matches input dim of layer i+1
 weights = [np.zeros((2, 3)), np.zeros((3, 1))]  # 3 == 3
 ```
+::tabs-end
+
 
 ---
 

--- a/articles/multi-headed-self-attention.md
+++ b/articles/multi-headed-self-attention.md
@@ -32,6 +32,7 @@ Create a list of `SingleHeadAttention` modules, each with attention dimension `a
 
 ### Implementation
 
+::tabs-start
 ```python
 import torch
 import torch.nn as nn
@@ -77,6 +78,8 @@ class MultiHeadedSelfAttention(nn.Module):
 
             return scores @ v
 ```
+::tabs-end
+
 
 ### Walkthrough
 
@@ -105,6 +108,7 @@ Each head projects from 8 to 2 dimensions (8/4 = 2), and concatenation restores 
 
 A plain Python list does not register sub-modules with PyTorch. Their parameters will not be updated during training.
 
+::tabs-start
 ```python
 # Wrong: parameters not tracked
 self.att_heads = []
@@ -116,11 +120,14 @@ self.att_heads = nn.ModuleList()
 for i in range(num_heads):
     self.att_heads.append(SingleHeadAttention(...))
 ```
+::tabs-end
+
 
 ### Wrong Head Dimension
 
 Each head should get `attention_dim // num_heads`, not `attention_dim`. Using the full dimension means each head is as large as a single-head attention, multiplying computation by $h$.
 
+::tabs-start
 ```python
 # Wrong: each head uses full dimension, total params * h
 SingleHeadAttention(embedding_dim, attention_dim)
@@ -128,6 +135,8 @@ SingleHeadAttention(embedding_dim, attention_dim)
 # Correct: each head uses 1/h of the dimension
 SingleHeadAttention(embedding_dim, attention_dim // num_heads)
 ```
+::tabs-end
+
 
 ---
 

--- a/articles/nlp-intro.md
+++ b/articles/nlp-intro.md
@@ -30,6 +30,7 @@ Combine positive and negative sentences, build a sorted vocabulary mapping words
 
 ### Implementation
 
+::tabs-start
 ```python
 import torch
 import torch.nn as nn
@@ -50,6 +51,8 @@ class Solution:
         # Pad shorter sequences with 0s so output is a rectangular tensor
         return nn.utils.rnn.pad_sequence(encoded, batch_first=True)
 ```
+::tabs-end
+
 
 ### Walkthrough
 
@@ -80,6 +83,7 @@ If one sentence were "I really love this" (length 4), the shorter one would beco
 
 If IDs start at 0, the first word gets ID 0, which is the same as padding. The model cannot distinguish between that word and padding positions.
 
+::tabs-start
 ```python
 # Wrong: first word gets ID 0 = padding
 word_to_id = {word: idx for idx, word in enumerate(vocabulary)}
@@ -87,11 +91,14 @@ word_to_id = {word: idx for idx, word in enumerate(vocabulary)}
 # Correct: IDs start at 1, reserving 0 for padding
 word_to_id = {word: idx + 1 for idx, word in enumerate(vocabulary)}
 ```
+::tabs-end
+
 
 ### Not Sorting the Vocabulary
 
 Without sorting, the vocabulary order depends on Python's set iteration order, which is non-deterministic. Different runs produce different ID assignments.
 
+::tabs-start
 ```python
 # Wrong: non-deterministic ordering
 vocabulary = list({word for sentence in combined for word in sentence.split()})
@@ -99,6 +106,8 @@ vocabulary = list({word for sentence in combined for word in sentence.split()})
 # Correct: sorted for reproducibility
 vocabulary = sorted({word for sentence in combined for word in sentence.split()})
 ```
+::tabs-end
+
 
 ---
 

--- a/articles/positional-encoding.md
+++ b/articles/positional-encoding.md
@@ -30,6 +30,7 @@ Construct a matrix of shape `(seq_len, d_model)`, compute position indices and f
 
 ### Implementation
 
+::tabs-start
 ```python
 import numpy as np
 from numpy.typing import NDArray
@@ -44,6 +45,8 @@ class Solution:
         PE[:, 1::2] = np.cos(position / div_term[:PE[:, 1::2].shape[1]])  # Odd indices: cosine
         return np.round(PE, 5)
 ```
+::tabs-end
+
 
 ### Walkthrough
 
@@ -70,6 +73,7 @@ Notice: low-frequency columns (0, 1) change rapidly with position, high-frequenc
 
 Sine goes on even indices only. Odd indices use cosine. Using the same function everywhere loses half the positional information.
 
+::tabs-start
 ```python
 # Wrong: sine everywhere
 PE[:, :] = np.sin(position / div_term_full)
@@ -78,11 +82,14 @@ PE[:, :] = np.sin(position / div_term_full)
 PE[:, 0::2] = np.sin(position / div_term)
 PE[:, 1::2] = np.cos(position / div_term[:num_odd_cols])
 ```
+::tabs-end
+
 
 ### Wrong Divisor Formula
 
 The divisor is $10000^{2i/d}$ where $i$ indexes pairs of dimensions. Using $10000^{i/d}$ (without the factor of 2) produces wrong frequencies.
 
+::tabs-start
 ```python
 # Wrong: missing factor of 2
 div_term = 10000 ** (np.arange(0, d_model, 2) / (d_model * 2))
@@ -90,6 +97,8 @@ div_term = 10000 ** (np.arange(0, d_model, 2) / (d_model * 2))
 # Correct: 2i/d, where arange(0, d_model, 2) already gives 2i
 div_term = 10000 ** (np.arange(0, d_model, 2) / d_model)
 ```
+::tabs-end
+
 
 ---
 

--- a/articles/self-attention.md
+++ b/articles/self-attention.md
@@ -36,6 +36,7 @@ Project the input into Q, K, V using linear layers. Compute attention scores as 
 
 ### Implementation
 
+::tabs-start
 ```python
 import torch
 import torch.nn as nn
@@ -69,6 +70,8 @@ class SingleHeadAttention(nn.Module):
 
         return torch.round(scores @ v, decimals=4)
 ```
+::tabs-end
+
 
 ### Walkthrough
 
@@ -96,6 +99,7 @@ For a sequence of 3 tokens with `embedding_dim = 4`, `attention_dim = 2`:
 
 Without scaling, large $d_k$ values make dot products large, pushing softmax into saturation where gradients vanish.
 
+::tabs-start
 ```python
 # Wrong: unscaled dot products
 scores = q @ torch.transpose(k, 1, 2)
@@ -106,11 +110,14 @@ scores = q @ torch.transpose(k, 1, 2)
 scores = scores / (attention_dim ** 0.5)
 scores = nn.functional.softmax(scores, dim=2)
 ```
+::tabs-end
+
 
 ### Applying the Mask After Softmax
 
 The mask must be applied before softmax. After softmax, setting values to zero does not produce a valid probability distribution (the remaining values would not sum to 1).
 
+::tabs-start
 ```python
 # Wrong: mask after softmax
 scores = nn.functional.softmax(scores, dim=2)
@@ -120,6 +127,8 @@ scores = scores.masked_fill(mask, 0)  # row doesn't sum to 1!
 scores = scores.masked_fill(mask, float('-inf'))
 scores = nn.functional.softmax(scores, dim=2)
 ```
+::tabs-end
+
 
 ---
 

--- a/articles/sentiment-analysis.md
+++ b/articles/sentiment-analysis.md
@@ -31,6 +31,7 @@ Define an embedding layer, a linear projection, and sigmoid. In the forward pass
 
 ### Implementation
 
+::tabs-start
 ```python
 import torch
 import torch.nn as nn
@@ -50,6 +51,8 @@ class Solution(nn.Module):
         projected = self.linear_layer(averaged)
         return torch.round(self.sigmoid_layer(projected), decimals=4)
 ```
+::tabs-end
+
 
 ### Walkthrough
 
@@ -75,6 +78,7 @@ For `x = [[3, 1, 4]]` (1 sentence, 3 tokens) and `vocabulary_size = 10`:
 
 `dim=0` averages across the batch (wrong: collapses different sentences together). `dim=1` averages across the sequence (correct: collapses words within each sentence).
 
+::tabs-start
 ```python
 # Wrong: averages across batch, mixing different sentences
 averaged = torch.mean(embeddings, dim=0)
@@ -82,11 +86,14 @@ averaged = torch.mean(embeddings, dim=0)
 # Correct: averages across sequence within each sentence
 averaged = torch.mean(embeddings, dim=1)
 ```
+::tabs-end
+
 
 ### Forgetting to Handle Padding
 
 If input sequences are padded with 0s, the padding tokens have their own embedding vectors that get included in the average. For this problem the test cases handle this, but in production you would mask padding before averaging.
 
+::tabs-start
 ```python
 # Simple (works for this problem)
 averaged = torch.mean(embeddings, dim=1)
@@ -95,6 +102,8 @@ averaged = torch.mean(embeddings, dim=1)
 mask = (x != 0).unsqueeze(-1).float()
 averaged = (embeddings * mask).sum(dim=1) / mask.sum(dim=1)
 ```
+::tabs-end
+
 
 ---
 

--- a/articles/sigmoid-and-relu.md
+++ b/articles/sigmoid-and-relu.md
@@ -34,6 +34,7 @@ Both functions are applied element-wise to a NumPy array. Sigmoid uses the formu
 
 ### Implementation
 
+::tabs-start
 ```python
 import numpy as np
 from numpy.typing import NDArray
@@ -47,6 +48,8 @@ class Solution:
     def relu(self, z: NDArray[np.float64]) -> NDArray[np.float64]:
         return np.maximum(0, z)
 ```
+::tabs-end
+
 
 ### Walkthrough
 
@@ -74,6 +77,7 @@ Notice that sigmoid compresses everything into $(0,1)$, while ReLU is identity f
 
 `np.max` returns the single largest element of an array. `np.maximum` compares element-wise.
 
+::tabs-start
 ```python
 # Wrong: returns a single scalar
 result = np.max(0, z)
@@ -81,11 +85,14 @@ result = np.max(0, z)
 # Correct: element-wise comparison with 0
 result = np.maximum(0, z)
 ```
+::tabs-end
+
 
 ### Numerical Overflow in Sigmoid
 
 For very large negative $z$ values, $e^{-z}$ overflows. A common fix is to use a conditional formula, but NumPy handles this gracefully for standard float64 ranges.
 
+::tabs-start
 ```python
 # Potentially unstable for extreme values
 result = 1 / (1 + np.exp(-z))
@@ -94,6 +101,8 @@ result = 1 / (1 + np.exp(-z))
 z_clipped = np.clip(z, -500, 500)
 result = 1 / (1 + np.exp(-z_clipped))
 ```
+::tabs-end
+
 
 ---
 

--- a/articles/single-neuron.md
+++ b/articles/single-neuron.md
@@ -34,6 +34,7 @@ We compute the dot product of inputs and weights using `np.dot`, add the bias, t
 
 ### Implementation
 
+::tabs-start
 ```python
 import numpy as np
 from numpy.typing import NDArray
@@ -50,6 +51,8 @@ class Solution:
             result = z
         return round(float(result), 5)
 ```
+::tabs-end
+
 
 ### Walkthrough
 
@@ -78,6 +81,7 @@ The negative $z$ means the input is "misaligned" with the weight direction. Sigm
 
 The bias shifts the decision boundary. Without it, the neuron can only represent functions that pass through the origin.
 
+::tabs-start
 ```python
 # Wrong: missing bias
 z = np.dot(x, w)
@@ -85,11 +89,14 @@ z = np.dot(x, w)
 # Correct: include bias
 z = np.dot(x, w) + b
 ```
+::tabs-end
+
 
 ### Using max() vs np.maximum() for Scalar ReLU
 
 For a single scalar, Python's built-in `max` works fine. But if you later vectorize to arrays, you need `np.maximum`.
 
+::tabs-start
 ```python
 # Fine for scalars
 result = max(0.0, z)
@@ -97,6 +104,8 @@ result = max(0.0, z)
 # Required for arrays (vectorized ReLU)
 result = np.maximum(0, z_array)
 ```
+::tabs-end
+
 
 ---
 

--- a/articles/softmax.md
+++ b/articles/softmax.md
@@ -33,6 +33,7 @@ We shift the input by subtracting the maximum value for numerical stability, exp
 
 ### Implementation
 
+::tabs-start
 ```python
 import numpy as np
 from numpy.typing import NDArray
@@ -45,6 +46,8 @@ class Solution:
         exps = np.exp(shifted)
         return np.round(exps / np.sum(exps), 4)
 ```
+::tabs-end
+
 
 ### Walkthrough
 
@@ -72,6 +75,7 @@ The largest logit (3.0) gets the highest probability (0.6652), and all three sum
 
 Without subtracting the max, large logits cause overflow.
 
+::tabs-start
 ```python
 # Wrong: overflows for large z values
 exps = np.exp(z)
@@ -82,11 +86,14 @@ shifted = z - np.max(z)
 exps = np.exp(shifted)
 return exps / np.sum(exps)
 ```
+::tabs-end
+
 
 ### Confusing Softmax with Sigmoid
 
 Sigmoid maps each element independently to $(0,1)$. Softmax creates a distribution that sums to 1 across all elements. They are not interchangeable.
 
+::tabs-start
 ```python
 # Wrong for multi-class: outputs don't sum to 1
 probs = 1 / (1 + np.exp(-z))
@@ -94,6 +101,8 @@ probs = 1 / (1 + np.exp(-z))
 # Correct for multi-class: proper probability distribution
 probs = np.exp(z - np.max(z)) / np.sum(np.exp(z - np.max(z)))
 ```
+::tabs-end
+
 
 ---
 

--- a/articles/tokenizer-bpe.md
+++ b/articles/tokenizer-bpe.md
@@ -33,6 +33,7 @@ Start with individual characters. At each step, count all adjacent pairs, find t
 
 ### Implementation
 
+::tabs-start
 ```python
 from typing import List
 
@@ -74,6 +75,8 @@ class Solution:
 
         return merges
 ```
+::tabs-end
+
 
 ### Walkthrough
 
@@ -100,6 +103,7 @@ Result: `[['a','a'], ['a','b'], ['aa','ab']]`
 
 When merging "aa" in "aaa", you get "aa" + "a" (non-overlapping, left to right), not "a" + "aa". The left-to-right scan prevents double-counting.
 
+::tabs-start
 ```python
 # Wrong: re-scanning allows overlapping merges
 for i in range(len(tokens) - 1):
@@ -118,11 +122,14 @@ while i < len(tokens):
         new_tokens.append(tokens[i])
         i += 1
 ```
+::tabs-end
+
 
 ### Wrong Tiebreaking
 
 When multiple pairs have the same frequency, lexicographic ordering ensures deterministic results. Without it, different runs may produce different merge tables.
 
+::tabs-start
 ```python
 # Wrong: arbitrary tiebreak
 best = max(pairs, key=pairs.get)
@@ -132,6 +139,8 @@ best_count = max(pairs.values())
 candidates = sorted(p for p, c in pairs.items() if c == best_count)
 best = candidates[0]
 ```
+::tabs-end
+
 
 ---
 

--- a/articles/train-your-gpt.md
+++ b/articles/train-your-gpt.md
@@ -36,6 +36,7 @@ For each epoch, sample a random batch, run the forward pass, compute cross-entro
 
 ### Implementation
 
+::tabs-start
 ```python
 import torch
 import torch.nn as nn
@@ -61,6 +62,8 @@ class Solution:
 
         return round(loss.item(), 4)
 ```
+::tabs-end
+
 
 ### Walkthrough
 
@@ -87,6 +90,7 @@ The reshape `logits.view(32, 50)` and `y.view(32)` flattens 4 sequences of 8 pos
 
 Without zeroing gradients, they accumulate across epochs. The updates become the sum of all previous gradients, causing erratic training.
 
+::tabs-start
 ```python
 # Wrong: gradients accumulate
 loss.backward()
@@ -97,11 +101,14 @@ optimizer.zero_grad()
 loss.backward()
 optimizer.step()
 ```
+::tabs-end
+
 
 ### Wrong Reshape for Cross-Entropy
 
 The logits must be $(B \cdot T, V)$ and targets must be $(B \cdot T)$. Getting the view dimensions wrong produces incorrect loss values or runtime errors.
 
+::tabs-start
 ```python
 # Wrong: forgot to flatten batch and time dimensions
 loss = F.cross_entropy(logits, y)  # shape mismatch
@@ -110,6 +117,8 @@ loss = F.cross_entropy(logits, y)  # shape mismatch
 B, T, C = logits.shape
 loss = F.cross_entropy(logits.view(B * T, C), y.view(B * T))
 ```
+::tabs-end
+
 
 ---
 

--- a/articles/training-loop.md
+++ b/articles/training-loop.md
@@ -33,6 +33,7 @@ Initialize weights to zeros and bias to zero. Each epoch: compute predictions, c
 
 ### Implementation
 
+::tabs-start
 ```python
 import numpy as np
 from numpy.typing import NDArray
@@ -60,6 +61,8 @@ class Solution:
 
         return (np.round(w, 5), round(float(b), 5))
 ```
+::tabs-end
+
 
 ### Walkthrough
 
@@ -85,6 +88,7 @@ The weights move toward the true relationship each epoch.
 
 The bias has its own gradient. If you only update weights, the model cannot learn functions with non-zero intercepts.
 
+::tabs-start
 ```python
 # Wrong: only updating weights
 w = w - lr * dw
@@ -94,11 +98,14 @@ w = w - lr * dw
 w = w - lr * dw
 b = b - lr * db
 ```
+::tabs-end
+
 
 ### Getting the Gradient Formula Wrong
 
 The MSE gradient has a factor of $2/N$. Getting this wrong changes the effective learning rate, which can cause divergence or slow convergence.
 
+::tabs-start
 ```python
 # Wrong: missing the 2/N factor
 dw = X.T @ error
@@ -106,6 +113,8 @@ dw = X.T @ error
 # Correct: properly scaled gradient
 dw = (2.0 / n) * (X.T @ error)
 ```
+::tabs-end
+
 
 ---
 

--- a/articles/transformer-block.md
+++ b/articles/transformer-block.md
@@ -35,6 +35,7 @@ The transformer block applies Pre-Norm attention with a skip connection, then Pr
 
 ### Implementation
 
+::tabs-start
 ```python
 import torch
 import torch.nn as nn
@@ -112,6 +113,8 @@ class TransformerBlock(nn.Module):
             torch.manual_seed(0)
             return self.dropout(self.down_projection(self.relu(self.up_projection(x))))
 ```
+::tabs-end
+
 
 ### Walkthrough
 
@@ -142,6 +145,7 @@ The output shape matches the input, so blocks can be stacked arbitrarily deep.
 
 Applying layer normalization after the sub-layer (Post-Norm) instead of before it (Pre-Norm) is less stable for deep networks.
 
+::tabs-start
 ```python
 # Wrong (Post-Norm): less stable for deep networks
 embedded = self.first_norm(embedded + self.attention(embedded))
@@ -149,11 +153,14 @@ embedded = self.first_norm(embedded + self.attention(embedded))
 # Correct (Pre-Norm): normalize before the sub-layer
 embedded = embedded + self.attention(self.first_norm(embedded))
 ```
+::tabs-end
+
 
 ### Forgetting the Residual Connection
 
 Without the skip path, the block must learn the full transformation, and gradients must pass through every sub-layer. Deep networks become untrainable.
 
+::tabs-start
 ```python
 # Wrong: no residual, gradients vanish in deep networks
 embedded = self.attention(self.first_norm(embedded))
@@ -161,6 +168,8 @@ embedded = self.attention(self.first_norm(embedded))
 # Correct: residual connection preserves gradient flow
 embedded = embedded + self.attention(self.first_norm(embedded))
 ```
+::tabs-end
+
 
 ---
 

--- a/articles/word-embeddings.md
+++ b/articles/word-embeddings.md
@@ -31,6 +31,7 @@ Embedding lookup is a single line of NumPy fancy indexing. Given an embedding ma
 
 ### Implementation
 
+::tabs-start
 ```python
 import numpy as np
 from numpy.typing import NDArray
@@ -40,6 +41,8 @@ class Solution:
     def lookup(self, embeddings: NDArray[np.float64], token_ids: NDArray[np.int64]) -> NDArray[np.float64]:
         return np.round(embeddings[token_ids], 5)
 ```
+::tabs-end
+
 
 ### Walkthrough
 
@@ -75,6 +78,7 @@ Result shape: $(3, 3)$.
 
 While mathematically equivalent to one-hot times $E$, actually constructing one-hot vectors is wasteful. Use indexing.
 
+::tabs-start
 ```python
 # Wrong: wasteful one-hot matrix multiply
 one_hot = np.eye(V)[token_ids]  # creates huge intermediate matrix
@@ -83,11 +87,14 @@ result = one_hot @ embeddings
 # Correct: direct indexing, O(1) per token
 result = embeddings[token_ids]
 ```
+::tabs-end
+
 
 ### Off-by-One Token IDs
 
 If your vocabulary starts at 1 (reserving 0 for padding), make sure the embedding matrix has $V+1$ rows, or subtract 1 from IDs before lookup.
 
+::tabs-start
 ```python
 # Wrong: token ID 5 indexes row 5, but if vocab starts at 1,
 # that's actually the 6th word
@@ -96,6 +103,8 @@ result = embeddings[token_ids]
 # Correct if IDs are 1-indexed: either expand matrix or shift IDs
 result = embeddings[token_ids - 1]
 ```
+::tabs-end
+
 
 ---
 


### PR DESCRIPTION
All 27 ML problem articles now have `::tabs-start`/`::tabs-end` markers around Python code blocks, enabling the copy button and syntax highlighting in the Solution tab on neetcode.io.


- **File(s) Modified**: articles/gradient-descent.md,
  articles/sigmoid-and-relu.md, articles/softmax.md,
  articles/cross-entropy-loss.md, articles/linear-regression-forward.md,
  articles/linear-regression-training.md, articles/single-neuron.md,
  articles/backpropagation.md, articles/mlp-from-scratch.md,
  articles/basics-of-pytorch.md, articles/layer-normalization.md,
  articles/training-loop.md, articles/handwritten-digit-classifier.md,
  articles/word-embeddings.md, articles/nlp-intro.md,
  articles/sentiment-analysis.md, articles/positional-encoding.md,
  articles/self-attention.md, articles/multi-headed-self-attention.md,
  articles/transformer-block.md, articles/tokenizer-bpe.md,
  articles/build-vocabulary.md, articles/gpt-data-loader.md,
  articles/gpt-dataset.md, articles/code-gpt.md, articles/train-your-gpt.md,
  articles/make-gpt-talk-back.md
  - **Language(s) Used**: markdown
  - **Submission URL**: N/A (article formatting fix, not a problem submission)
