### PR TITLE
Fix Java two-stack solution article on minimum-stack.md

### DIFF
--- a/articles/minimum-stack.md
+++ b/articles/minimum-stack.md
@@ -457,7 +457,7 @@ public class MinStack {
 
     public void pop() {
         if (stack.isEmpty()) return;
-        int top = stack.pop();
+        Integer top = stack.pop();
         if (top.equals(minStack.peek())) {
             minStack.pop();
         }


### PR DESCRIPTION
- **File(s) Modified**: _articles/minimum-stack.md_
- **Language(s) Used**: _markdown, java_
- **Submission URL**: _https://leetcode.com/problems/min-stack/submissions/1966317228/_

The existing code sample as-is does not pass.

Equality for non-primitive `Integer` objects should be checked with `.equals()`
`==` is otherwise checking the reference is to the same object

Java has a pitfall where it caches (and reuses) small Integers (-128 to 127) by default. This can make you think `==` is working as expected.

[//]: # 'Getting the Submission URL'
[//]: # 'Go to the leetcode [`Submissions tab`](https://user-images.githubusercontent.com/71089234/180188604-b1ecaf90-bf27-4fd6-a559-5567aebf8930.png)'
[//]: # 'and [click on the `Accepted` status of your submission.](https://user-images.githubusercontent.com/71089234/180189321-1a48c33f-aa65-4b29-8aaa-685f4f5f8c9e.png)]'
[//]: # 'Finally copy the URL from the nav bar, it should look like https://leetcode.com/problems/[problem-name]/submissions/xxxxxxxxx/'
