### PR TITLE
Ml/pr5 solution articles

### DIFF
--- a/articles/grouped-query-attention.md
+++ b/articles/grouped-query-attention.md
@@ -1,0 +1,156 @@
+## Prerequisites
+
+Before attempting this problem, you should be comfortable with:
+
+- **Multi-Head Self-Attention** - GQA modifies how heads share K and V, so understanding standard MHA with independent KV heads per query head is essential
+- **KV-Cache** - GQA's primary motivation is reducing the KV-Cache memory footprint during inference, so understanding the cache size problem comes first
+- **Tensor Reshaping** - The implementation requires `view`, `transpose`, and `repeat_interleave` to reshape between `(B, T, D)` and `(B, heads, T, head_dim)` formats
+
+---
+
+## Concept
+
+Standard Multi-Head Attention gives every query head its own K and V projections. During inference with KV-Cache, all those K and V tensors must be stored, and the memory cost scales linearly with the number of heads. Grouped Query Attention reduces this by sharing K, V across groups of query heads.
+
+With $h$ query heads and $g$ KV heads, each KV head serves $h/g$ query heads. The key operation is `repeat_interleave`: it expands the $g$ KV heads to $h$ by repeating each one $h/g$ times, making the shapes match for standard attention math. When $g = h$, GQA is identical to MHA. When $g = 1$, it becomes Multi-Query Attention.
+
+---
+
+## Solution
+
+### Intuition
+
+Project x into Q with `num_heads` heads and K, V with `num_kv_heads` heads. Reshape into the multi-head format. Expand K and V by repeating each KV head to match Q's head count. From here, it's standard scaled dot-product attention with a causal mask. Concatenate the heads and apply the output projection.
+
+### Implementation
+
+::tabs-start
+```python
+import torch
+import torch.nn as nn
+from torchtyping import TensorType
+
+class GroupedQueryAttention(nn.Module):
+    def __init__(self, model_dim: int, num_heads: int, num_kv_heads: int):
+        super().__init__()
+        torch.manual_seed(0)
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = model_dim // num_heads
+
+        self.q_proj = nn.Linear(model_dim, num_heads * self.head_dim, bias=False)
+        self.k_proj = nn.Linear(model_dim, num_kv_heads * self.head_dim, bias=False)
+        self.v_proj = nn.Linear(model_dim, num_kv_heads * self.head_dim, bias=False)
+        self.output_proj = nn.Linear(num_heads * self.head_dim, model_dim, bias=False)
+
+    def forward(self, x: TensorType[float]) -> TensorType[float]:
+        B, T, D = x.shape
+
+        # Project to Q, K, V and reshape into heads
+        q = self.q_proj(x).view(B, T, self.num_heads, self.head_dim).transpose(1, 2)
+        k = self.k_proj(x).view(B, T, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = self.v_proj(x).view(B, T, self.num_kv_heads, self.head_dim).transpose(1, 2)
+
+        # Expand K, V to match Q's num_heads by repeating each KV head
+        repeats = self.num_heads // self.num_kv_heads
+        k = k.repeat_interleave(repeats, dim=1)
+        v = v.repeat_interleave(repeats, dim=1)
+
+        # Scaled dot-product attention with causal mask
+        scores = (q @ k.transpose(-2, -1)) * (self.head_dim ** -0.5)
+        mask = torch.tril(torch.ones(T, T, device=x.device))
+        scores = scores.masked_fill(mask == 0, float('-inf'))
+        weights = torch.softmax(scores, dim=-1)
+
+        out = (weights @ v).transpose(1, 2).contiguous().view(B, T, -1)
+        return torch.round(self.output_proj(out), decimals=4)
+```
+::tabs-end
+
+
+### Walkthrough
+
+For `model_dim=8`, `num_heads=4`, `num_kv_heads=2`:
+
+| Step | Operation | Shape |
+|---|---|---|
+| Q projection | `q_proj(x)` then reshape | `(B, 4, T, 2)` -- 4 query heads, head_dim=2 |
+| K projection | `k_proj(x)` then reshape | `(B, 2, T, 2)` -- only 2 KV heads |
+| V projection | `v_proj(x)` then reshape | `(B, 2, T, 2)` -- only 2 KV heads |
+| Expand K | `repeat_interleave(2, dim=1)` | `(B, 4, T, 2)` -- each KV head repeated 2x |
+| Expand V | `repeat_interleave(2, dim=1)` | `(B, 4, T, 2)` -- now matches Q |
+| Attention | Standard scaled dot-product | `(B, 4, T, 2)` per head |
+| Concat + project | Merge heads, output projection | `(B, T, 8)` |
+
+**Memory savings:** K and V projections produce `num_kv_heads * head_dim = 2 * 2 = 4` values per token instead of `num_heads * head_dim = 4 * 2 = 8`. In the KV-Cache, this halves the memory per layer. For Llama 2 70B (64 query heads, 8 KV heads), the savings are 8x.
+
+### Time & Space Complexity
+
+- Time: $O(T^2 \cdot d)$ for attention (same as MHA, since K, V are expanded before the attention computation)
+- Space: $O(g \cdot T \cdot d_h)$ for KV-Cache storage, where $g$ is the number of KV heads and $d_h$ is the head dimension. This is $g/h$ of standard MHA.
+
+---
+
+## Common Pitfalls
+
+### Using `repeat` Instead of `repeat_interleave`
+
+`repeat` tiles the entire tensor, while `repeat_interleave` repeats each element individually. With 2 KV heads and 4 query heads, you want `[KV0, KV0, KV1, KV1]`, not `[KV0, KV1, KV0, KV1]`.
+
+::tabs-start
+```python
+# Wrong: repeat tiles the whole tensor
+k = k.repeat(1, repeats, 1, 1)  # [KV0, KV1, KV0, KV1] -- wrong grouping!
+
+# Correct: repeat_interleave repeats each element
+k = k.repeat_interleave(repeats, dim=1)  # [KV0, KV0, KV1, KV1] -- correct groups
+```
+::tabs-end
+
+
+### Forgetting the Causal Mask
+
+GQA is used in decoder-only models (GPT, Llama) where tokens must not attend to future positions. Without the lower-triangular mask, the model breaks autoregressive generation.
+
+::tabs-start
+```python
+# Wrong: no causal mask
+weights = torch.softmax(scores, dim=-1)
+
+# Correct: apply causal mask before softmax
+mask = torch.tril(torch.ones(T, T, device=x.device))
+scores = scores.masked_fill(mask == 0, float('-inf'))
+weights = torch.softmax(scores, dim=-1)
+```
+::tabs-end
+
+
+### Wrong Reshape Order
+
+The view/transpose sequence matters. Q has `num_heads` heads, but K and V have `num_kv_heads` heads. Using `num_heads` for the K reshape would produce incorrect head dimensions.
+
+::tabs-start
+```python
+# Wrong: reshaping K with num_heads
+k = self.k_proj(x).view(B, T, self.num_heads, self.head_dim)  # Shape mismatch!
+
+# Correct: reshaping K with num_kv_heads
+k = self.k_proj(x).view(B, T, self.num_kv_heads, self.head_dim)
+```
+::tabs-end
+
+
+---
+
+## In the GPT Project
+
+GQA is the attention variant used by Llama 2/3, Mistral, and Gemma. In a full GPT implementation, you would combine GQA with KV-Cache from the previous problem: the cache stores only `num_kv_heads` worth of K, V per layer (not `num_heads`), giving a direct memory reduction proportional to the head ratio.
+
+---
+
+## Key Takeaways
+
+- GQA shares K and V across groups of query heads, reducing KV-Cache memory by a factor of `num_heads / num_kv_heads` with minimal quality loss.
+- `repeat_interleave` is the key operation: it expands each KV head to serve its assigned group of query heads, making the shapes compatible for standard attention.
+- GQA generalizes both MHA ($g = h$) and MQA ($g = 1$). Most production models use an intermediate value (e.g., Llama 2 70B uses 64 query heads with 8 KV heads).
+- The attention computation after expansion is identical to standard MHA. The savings come entirely from the smaller projection layers and smaller cache.

--- a/articles/kv-cache.md
+++ b/articles/kv-cache.md
@@ -1,0 +1,149 @@
+## Prerequisites
+
+Before attempting this problem, you should be comfortable with:
+
+- **Self-Attention** - KV-Cache optimizes the attention computation, so you need to understand Q, K, V projections and the scaled dot-product formula
+- **Autoregressive Generation** - The cache only helps during generation (one new token at a time), not during the initial prompt processing
+- **Tensor Concatenation** - The cache grows by concatenating new K, V along the sequence dimension with `torch.cat`
+
+---
+
+## Concept
+
+During autoregressive generation, each new token requires attending to all previous tokens. Without caching, this means recomputing K and V for the entire context at every step -- quadratic total work. KV-Cache stores the K and V tensors from previous steps and only computes new K, V for the current token, then concatenates.
+
+The key insight: K and V for previous tokens do not change between generation steps. Only Q needs to be computed fresh for the new token. The cache turns an $O(N^2)$ total cost (across $N$ generation steps) into $O(N)$ per step.
+
+---
+
+## Solution
+
+### Intuition
+
+The `KVCache` class stores K and V tensors and grows them by concatenating along the sequence dimension. The `CachedAttention` module projects the new input into Q, K, V, updates the cache with the new K and V, then computes attention using Q (from just the new token) against the full cached K and V (from all tokens so far).
+
+### Implementation
+
+::tabs-start
+```python
+import torch
+import torch.nn as nn
+from typing import Tuple, Optional
+
+class KVCache:
+    def __init__(self):
+        self.cache_k: Optional[torch.Tensor] = None
+        self.cache_v: Optional[torch.Tensor] = None
+
+    def update(self, new_k: torch.Tensor, new_v: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        if self.cache_k is None:
+            self.cache_k = new_k
+            self.cache_v = new_v
+        else:
+            self.cache_k = torch.cat([self.cache_k, new_k], dim=1)
+            self.cache_v = torch.cat([self.cache_v, new_v], dim=1)
+        return self.cache_k, self.cache_v
+
+    def clear(self):
+        self.cache_k = None
+        self.cache_v = None
+
+class CachedAttention(nn.Module):
+    def __init__(self, model_dim: int):
+        super().__init__()
+        torch.manual_seed(0)
+        self.q_proj = nn.Linear(model_dim, model_dim, bias=False)
+        self.k_proj = nn.Linear(model_dim, model_dim, bias=False)
+        self.v_proj = nn.Linear(model_dim, model_dim, bias=False)
+
+    def forward(self, x: torch.Tensor, kv_cache: Optional[KVCache] = None) -> Tuple[torch.Tensor, KVCache]:
+        q = self.q_proj(x)
+        k = self.k_proj(x)
+        v = self.v_proj(x)
+
+        if kv_cache is None:
+            kv_cache = KVCache()
+
+        full_k, full_v = kv_cache.update(k, v)
+
+        # Scaled dot-product attention
+        scores = (q @ full_k.transpose(-2, -1)) * (full_k.shape[-1] ** -0.5)
+        weights = torch.softmax(scores, dim=-1)
+        output = weights @ full_v
+
+        return torch.round(output, decimals=4), kv_cache
+```
+::tabs-end
+
+
+### Walkthrough
+
+Generating 3 tokens step by step:
+
+| Step | Input Shape | Cache K Before | Operation | Cache K After |
+|---|---|---|---|---|
+| 1 | `(1, 1, 4)` | empty | Init cache with $k_1$ | `(1, 1, 4)` |
+| 2 | `(1, 1, 4)` | `(1, 1, 4)` | Concat $k_2$: `cat([k_1, k_2], dim=1)` | `(1, 2, 4)` |
+| 3 | `(1, 1, 4)` | `(1, 2, 4)` | Concat $k_3$: `cat([k_1, k_2, k_3], dim=1)` | `(1, 3, 4)` |
+
+At step 3, the attention computation is:
+- Q shape: `(1, 1, 4)` (only the new token's query)
+- K shape: `(1, 3, 4)` (all 3 tokens' keys from cache)
+- Scores: `(1, 1, 4) @ (1, 4, 3)` = `(1, 1, 3)` (one attention weight per cached token)
+- Output: `(1, 1, 3) @ (1, 3, 4)` = `(1, 1, 4)` (weighted sum of all 3 values)
+
+### Time & Space Complexity
+
+- Time: $O(N \cdot d)$ per generation step, where $N$ is the current sequence length and $d$ is model dimension. Without cache, each step would be $O(N^2 \cdot d)$.
+- Space: $O(N \cdot d)$ for the cached K and V tensors, growing linearly with sequence length.
+
+---
+
+## Common Pitfalls
+
+### Concatenating Along the Wrong Dimension
+
+K and V have shape `(batch, seq_len, model_dim)`. The cache grows along `dim=1` (sequence length). Concatenating along `dim=0` (batch) or `dim=2` (model_dim) would corrupt the tensors.
+
+::tabs-start
+```python
+# Wrong: concatenating along batch dimension
+self.cache_k = torch.cat([self.cache_k, new_k], dim=0)
+
+# Correct: concatenating along sequence dimension
+self.cache_k = torch.cat([self.cache_k, new_k], dim=1)
+```
+::tabs-end
+
+
+### Recomputing K, V for the Full Context
+
+The whole point of the cache is to avoid recomputing K, V for previous tokens. If you project the full context through `k_proj` and `v_proj` at each step, you lose the speedup entirely.
+
+::tabs-start
+```python
+# Wrong: projecting full context (defeats the purpose)
+full_input = torch.cat([previous_tokens, new_token], dim=1)
+k = self.k_proj(full_input)  # Recomputes K for all tokens!
+
+# Correct: only project the new token
+k = self.k_proj(x)  # x is only the new token
+full_k, full_v = kv_cache.update(k, v)  # Cache handles history
+```
+::tabs-end
+
+
+---
+
+## In the GPT Project
+
+KV-Cache is the single most important inference optimization. Every production LLM (ChatGPT, Claude, Gemini) uses it. Without it, generating 1000 tokens would require $\sum_{i=1}^{1000} i^2 \approx 333$ million attention operations instead of $\sum_{i=1}^{1000} i \approx 500{,}000$. This module becomes the foundation for further optimizations like Grouped Query Attention and Paged Attention.
+
+---
+
+## Key Takeaways
+
+- KV-Cache stores K and V from previous tokens so they don't need to be recomputed. Only the new token's K and V are computed and appended.
+- The cache grows by one entry per generation step via `torch.cat` along the sequence dimension.
+- No causal mask is needed in the cached forward pass: the cache naturally contains only past tokens, enforcing causality by construction.
+- The memory cost is linear in sequence length ($O(N \cdot d)$ per layer), which is why long context windows are expensive. This motivates optimizations like Grouped Query Attention (fewer KV heads = smaller cache).


### PR DESCRIPTION
## Add solution articles for KV-Cache and Grouped Query Attention

### Summary

Adds solution articles for 2 new ML problems.

### Articles

- `articles/kv-cache.md` — KV-Cache implementation for inference speedup
- `articles/grouped-query-attention.md` — Grouped Query Attention (GQA) vs MHA/MQA

### Test Plan

- [x] Articles render correctly in the Solutions tab