### PR TITLE
Fix LC 787: Correct SPFA time complexity and harden test suite

### DIFF
--- a/articles/cheapest-flight-path.md
+++ b/articles/cheapest-flight-path.md
@@ -1032,7 +1032,7 @@ impl Solution {
 
 ### Time & Space Complexity
 
-- Time complexity: $O(n * k)$
+- Time complexity: $O(m * k)$
 - Space complexity: $O(n + m)$
 
 > Where $n$ is the number of cities, $m$ is the number of flights and $k$ is the number of stops.


### PR DESCRIPTION
- **File(s) Modified**: _articles/cheapest-flight-path.md_
- **Language(s) Used**: _markdown_
- **Submission URL**: _N/A (Documentation/Article update)_

### Description
This PR addresses Issues #5796 and #5797 by correcting the time complexity analysis in the written article for LC 787 and providing an additional test case to strengthen backend test coverage.

**1. Article Update (#5797)**
Updated the time complexity analysis for the Shortest Path Faster Algorithm (SPFA) solution. The article previously stated the time complexity was $O(n \cdot k)$. This has been corrected to $O(m \cdot k)$ (where $m$ is the number of edges/flights), as the algorithm iterates through all edges connected to the current node at each level up to $k$ times.

**2. Backend Action Required: Hardening Test Coverage (#5796)**
The current backend test suite is missing a test case to catch incorrect Dijkstra implementations. Specifically, solutions that permanently track visited nodes using a `shortest` dictionary (e.g., `if node not in shortest: shortest[node] = w`) will incorrectly block valid paths that reach a node with a higher cost but fewer stops. 

Please add the following test case to the private execution engine database to properly fail these incorrect submissions:

**Input:** `n = 5`
`flights = [[0,1,1],[1,2,1],[2,3,1],[3,4,1],[0,2,10]]`
`src = 0`
`dst = 4`
`k = 2`

**Expected Output:** `12`

Resolves #5796, Resolves #5797