### PR TITLE
Fix/user reported bugs

### DIFF
--- a/articles/binary-search-tree-iterator.md
+++ b/articles/binary-search-tree-iterator.md
@@ -390,7 +390,7 @@ impl BSTIterator {
 
 - Time complexity:
     - $O(n)$ time for initialization.
-    - $O(n)$ time for each $next()$ and $hasNext()$ function calls.
+    - $O(1)$ time for each $next()$ and $hasNext()$ function call.
 - Space complexity: $O(n)$
 
 ---
@@ -758,7 +758,7 @@ impl BSTIterator {
 
 - Time complexity:
     - $O(n)$ time for initialization.
-    - $O(n)$ time for each $next()$ and $hasNext()$ function calls.
+    - $O(1)$ time for each $next()$ and $hasNext()$ function call.
 - Space complexity: $O(n)$
 
 ---

--- a/articles/find-critical-and-pseudo-critical-edges-in-minimum-spanning-tree.md
+++ b/articles/find-critical-and-pseudo-critical-edges-in-minimum-spanning-tree.md
@@ -2698,7 +2698,7 @@ func findCriticalAndPseudoCriticalEdges(n int, edges [][]int) [][]int {
 
     uf := NewUnionFind(n)
     for _, edge := range edgeList {
-        w, u, v, idx := edge[0], edge[1], edge[2], edge[3]
+        _, u, v, idx := edge[0], edge[1], edge[2], edge[3]
         if uf.Union(u, v) {
             mst[u] = append(mst[u], [2]int{v, idx})
             mst[v] = append(mst[v], [2]int{u, idx})

--- a/articles/find-critical-and-pseudo-critical-edges-in-minimum-spanning-tree.md
+++ b/articles/find-critical-and-pseudo-critical-edges-in-minimum-spanning-tree.md
@@ -1593,7 +1593,7 @@ class Solution:
             pq = [(0, src)]
 
             while pq:
-                max_w, u = heappop(pq)
+                max_w, u = heapq.heappop(pq)
                 if u == dst:
                     return max_w
 
@@ -1603,7 +1603,7 @@ class Solution:
                     new_w = max(max_w, weight)
                     if new_w < dist[v]:
                         dist[v] = new_w
-                        heappush(pq, (new_w, v))
+                        heapq.heappush(pq, (new_w, v))
 
             return float('inf')
 

--- a/articles/lemonade-change.md
+++ b/articles/lemonade-change.md
@@ -2,7 +2,7 @@
 
 Before attempting this problem, you should be comfortable with:
 
-- **Greedy Algorithms** - Making optimal local decisions at each step (prioritizing $10 bills for $15 change to preserve flexibility)
+- **Greedy Algorithms** - Making optimal local decisions at each step (prioritizing \$10 bills for \$15 change to preserve flexibility)
 - **Basic Iteration** - Processing elements sequentially while maintaining state
 - **Simple Counting** - Tracking quantities of different bill denominations using variables
 
@@ -561,10 +561,10 @@ impl Solution {
 
 ## Common Pitfalls
 
-### Using Three $5 Bills Before One $10 and One $5
+### Using Three \$5 Bills Before One \$10 and One \$5
 
-When giving $15 change for a $20 bill, you should prefer using one $10 and one $5 over three $5 bills. The $5 bills are more versatile since they can be used for both $5 and $10 change scenarios. Using three $5 bills depletes your flexibility for future transactions.
+When giving \$15 change for a \$20 bill, you should prefer using one \$10 and one \$5 over three \$5 bills. The \$5 bills are more versatile since they can be used for both \$5 and \$10 change scenarios. Using three \$5 bills depletes your flexibility for future transactions.
 
-### Not Tracking the $10 Bill Count
+### Not Tracking the \$10 Bill Count
 
-Some solutions only track $5 bills, assuming $10 bills are not useful. However, $10 bills are essential for efficiently making $15 change. Failing to track them means you cannot implement the optimal greedy strategy and may incorrectly return `false` when change is actually possible.
+Some solutions only track \$5 bills, assuming \$10 bills are not useful. However, \$10 bills are essential for efficiently making \$15 change. Failing to track them means you cannot implement the optimal greedy strategy and may incorrectly return `false` when change is actually possible.

--- a/articles/longest-repeating-substring-with-replacement.md
+++ b/articles/longest-repeating-substring-with-replacement.md
@@ -568,9 +568,13 @@ Because the characters that _aren't_ the most frequent are the ones we would nee
 So while expanding the window, we track:
 
 - the frequency of each character,
-- the most frequent character inside the window (`maxf`).
+- the highest frequency we have seen in the window as it grows (`maxf`).
 
-If the window becomes invalid, we shrink it from the left.
+After we shrink from the left, `maxf` may be stale because we do not decrease it.
+That can temporarily make the current window look valid even when its true current maximum frequency is smaller.
+This is still correct because such a stale value never increases the answer beyond a window length that was already achievable when `maxf` was accurate.
+
+If the window is too large under this tracked `maxf`, we shrink it from the left.
 This gives us one clean sliding window pass.
 
 ### Algorithm
@@ -579,9 +583,9 @@ This gives us one clean sliding window pass.
 2. Move the right pointer `r` across the string:
     - Update the frequency of `s[r]`.
     - Update `maxf` with the highest frequency seen so far.
-3. If the window is invalid (`window size - maxf > k`):
+3. If the tracked condition is violated (`window size - maxf > k`):
     - Shrink the window from the left and adjust counts.
-4. Update the result with the valid window size.
+4. Update the result with the current window size.
 5. Return `res` at the end.
 
 ::tabs-start
@@ -826,11 +830,11 @@ impl Solution {
 
 ### Not Updating maxf Correctly
 
-The variable `maxf` tracks the maximum frequency of any character in the current window. A common mistake is recalculating the maximum by iterating through all counts after shrinking the window. In the optimal solution, you do not need to decrease `maxf` when shrinking because keeping a stale (higher) `maxf` only makes the window condition stricter, which is still correct. However, misunderstanding this can lead to unnecessary complexity or bugs.
+The variable `maxf` tracks the highest frequency seen while expanding the window, not necessarily the exact maximum frequency after every shrink. A common mistake is recalculating the maximum by iterating through all counts after moving the left pointer. In the optimal solution, you do not need to decrease `maxf` when shrinking. A stale, higher `maxf` can temporarily make the validity check more permissive and allow an actually invalid current window, but it does not affect correctness because it cannot make the algorithm record a length larger than one that was achievable when `maxf` was accurate.
 
 ### Shrinking the Window Too Aggressively
 
-When the window becomes invalid (`window size - maxf > k`), you only need to shrink it enough to make it valid again. A common error is resetting the left pointer too far or not updating character counts properly when moving the left pointer. Make sure to decrement the count of `s[l]` before incrementing `l`.
+When the tracked condition is violated (`window size - maxf > k`), you only need to shrink until that condition passes again. A common error is resetting the left pointer too far or not updating character counts properly when moving the left pointer. Make sure to decrement the count of `s[l]` before incrementing `l`.
 
 ### Confusing Window Size Calculation
 

--- a/articles/min-cost-climbing-stairs.md
+++ b/articles/min-cost-climbing-stairs.md
@@ -428,10 +428,10 @@ Instead of solving the problem recursively, we build the answer **from the botto
 Let `dp[i]` represent the **minimum cost to reach step `i`**.
 To reach step `i`, you can:
 
-- Come from step `i-1` and pay `cost[i-1]`
-- Come from step `i-2` and pay `cost[i-2]`
+- Come from step `i-1`, after spending `dp[i-1]` to get there, then pay `cost[i-1]`
+- Come from step `i-2`, after spending `dp[i-2]` to get there, then pay `cost[i-2]`
 
-We choose the cheaper of the two.
+We choose the cheaper total cost, not just the cheaper single step cost.
 
 ### Algorithm
 

--- a/articles/path-with-maximum-probability.md
+++ b/articles/path-with-maximum-probability.md
@@ -19,9 +19,9 @@ This problem asks for the path with maximum probability, which is similar to fin
 
 1. Build an adjacency list where each node maps to its neighbors and the corresponding edge probabilities.
 2. Use a max-heap (priority queue) to always process the node with the highest probability first. Start with probability `1.0` at the source node.
-3. Mark nodes as visited once processed to avoid redundant work.
+3. Avoid redundant work by either marking nodes as visited once processed, or by keeping the best known probability for each node and skipping stale heap entries.
 4. For each node popped from the heap, if it is the destination, return the current probability.
-5. Otherwise, for each unvisited neighbor, compute the new probability by multiplying the current probability with the edge probability, and push it to the heap.
+5. Otherwise, for each eligible neighbor, compute the new probability by multiplying the current probability with the edge probability, and push it to the heap.
 6. If the destination is never reached, return `0`.
 
 ::tabs-start
@@ -75,7 +75,7 @@ public class Solution {
             double curr_prob = top.prob;
 
             if (node == end_node) return curr_prob;
-            if (curr_prob > maxProb[node]) continue;
+            if (curr_prob < maxProb[node]) continue;
 
             for (Pair nei : adj[node]) {
                 double new_prob = curr_prob * nei.prob;
@@ -121,7 +121,7 @@ public:
             auto [curr_prob, node] = pq.top(); pq.pop();
 
             if (node == end_node) return curr_prob;
-            if (curr_prob > maxProb[node]) continue;
+            if (curr_prob < maxProb[node]) continue;
 
             for (auto& [nei, edge_prob] : adj[node]) {
                 double new_prob = curr_prob * edge_prob;
@@ -393,10 +393,10 @@ impl Solution {
         let mut max_prob = vec![0.0f64; n];
         max_prob[start] = 1.0;
         let mut pq = BinaryHeap::new();
-        pq.push((std::cmp::Reverse((-1.0f64).to_bits()), start));
+        pq.push((1.0f64.to_bits(), start));
 
-        while let Some((std::cmp::Reverse(bits), node)) = pq.pop() {
-            let curr_prob = -f64::from_bits(bits);
+        while let Some((bits, node)) = pq.pop() {
+            let curr_prob = f64::from_bits(bits);
             if node == end {
                 return curr_prob;
             }
@@ -407,7 +407,7 @@ impl Solution {
                 let new_prob = curr_prob * edge_prob;
                 if new_prob > max_prob[nei] {
                     max_prob[nei] = new_prob;
-                    pq.push((std::cmp::Reverse((-new_prob).to_bits()), nei));
+                    pq.push((new_prob.to_bits(), nei));
                 }
             }
         }
@@ -439,7 +439,7 @@ This is a refined version of Dijkstra's algorithm that tracks the maximum probab
 1. Build an adjacency list mapping each node to its neighbors and edge probabilities.
 2. Initialize a `maxProb` array where `maxProb[i]` stores the highest probability to reach node `i`. Set `maxProb[start] = 1.0`.
 3. Use a max-heap starting with `(1.0, start_node)`.
-4. For each node popped from the heap, if it is the destination, return the probability. If the current probability is worse than the recorded best, skip it.
+4. For each node popped from the heap, if it is the destination, return the probability. If the current probability is worse than the recorded best (`curr_prob < maxProb[node]`), skip it.
 5. For each neighbor, compute the new probability. If it improves the best known probability for that neighbor, update the array and push the neighbor to the heap.
 6. Return `0` if the destination is unreachable.
 
@@ -464,7 +464,7 @@ class Solution:
 
             if node == end_node:
                 return curr_prob
-            if curr_prob > maxProb[node]:
+            if curr_prob < maxProb[node]:
                 continue
 
             for nei, edge_prob in adj[node]:
@@ -499,7 +499,7 @@ public class Solution {
             double curr_prob = top.prob;
 
             if (node == end_node) return curr_prob;
-            if (curr_prob > maxProb[node]) continue;
+            if (curr_prob < maxProb[node]) continue;
 
             for (Pair nei : adj[node]) {
                 double new_prob = curr_prob * nei.prob;
@@ -545,7 +545,7 @@ public:
             auto [curr_prob, node] = pq.top(); pq.pop();
 
             if (node == end_node) return curr_prob;
-            if (curr_prob > maxProb[node]) continue;
+            if (curr_prob < maxProb[node]) continue;
 
             for (auto& [nei, edge_prob] : adj[node]) {
                 double new_prob = curr_prob * edge_prob;
@@ -588,7 +588,7 @@ class Solution {
             let [node, curr_prob] = pq.dequeue();
 
             if (node === end_node) return curr_prob;
-            if (curr_prob > maxProb[node]) continue;
+            if (curr_prob < maxProb[node]) continue;
 
             for (let [nei, edge_prob] of adj[node]) {
                 let new_prob = curr_prob * edge_prob;
@@ -820,10 +820,10 @@ impl Solution {
         let mut max_prob = vec![0.0f64; n];
         max_prob[start] = 1.0;
         let mut pq = BinaryHeap::new();
-        pq.push((std::cmp::Reverse((-1.0f64).to_bits()), start));
+        pq.push((1.0f64.to_bits(), start));
 
-        while let Some((std::cmp::Reverse(bits), node)) = pq.pop() {
-            let curr_prob = -f64::from_bits(bits);
+        while let Some((bits, node)) = pq.pop() {
+            let curr_prob = f64::from_bits(bits);
             if node == end {
                 return curr_prob;
             }
@@ -834,7 +834,7 @@ impl Solution {
                 let new_prob = curr_prob * edge_prob;
                 if new_prob > max_prob[nei] {
                     max_prob[nei] = new_prob;
-                    pq.push((std::cmp::Reverse((-new_prob).to_bits()), nei));
+                    pq.push((new_prob.to_bits(), nei));
                 }
             }
         }
@@ -1513,6 +1513,12 @@ impl Solution {
 ### Using Min-Heap Instead of Max-Heap
 
 Unlike shortest path problems where we minimize distance, this problem requires maximizing probability. Using a min-heap (the default in most languages) will process low-probability paths first, leading to incorrect results or inefficiency. Always use a max-heap or negate the probabilities when using a min-heap.
+
+In Rust, be careful when using `to_bits()` as a heap key. Storing `Reverse((-prob).to_bits())` does not order probabilities like a numeric max-heap, and can pop a lower probability before a higher one. Since probabilities are non-negative, storing `prob.to_bits()` in a `BinaryHeap` preserves the needed order.
+
+### Reversing the Stale-State Check
+
+When using a `maxProb` array, a heap entry is stale only when its probability is lower than the best probability already recorded for that node. The check should be `curr_prob < maxProb[node]`, not `curr_prob > maxProb[node]`.
 
 ### Initializing Start Probability to Zero
 

--- a/articles/sqrtx.md
+++ b/articles/sqrtx.md
@@ -221,6 +221,8 @@ Most programming languages provide a built-in square root function that computes
 ::tabs-start
 
 ```python
+from math import sqrt
+
 class Solution:
     def mySqrt(self, x: int) -> int:
         return int(sqrt(x))

--- a/articles/string-encode-and-decode.md
+++ b/articles/string-encode-and-decode.md
@@ -2,7 +2,7 @@
 
 Before attempting this problem, you should be comfortable with:
 
-- **String Manipulation** - Building strings by concatenation and extracting substrings based on indices
+- **String Manipulation** - Building encoded strings and extracting substrings based on indices
 - **Delimiter Design** - Understanding how to choose separators that won't conflict with input content
 - **Length-Prefix Encoding** - Using string lengths to unambiguously mark boundaries between encoded segments
 
@@ -46,28 +46,26 @@ class Solution:
     def encode(self, strs: List[str]) -> str:
         if not strs:
             return ""
-        sizes, res = [], ""
+        sizes, res = [], []
         for s in strs:
             sizes.append(len(s))
         for sz in sizes:
-            res += str(sz)
-            res += ','
-        res += '#'
-        for s in strs:
-            res += s
-        return res
+            res.append(str(sz))
+            res.append(',')
+        res.append('#')
+        res.extend(strs)
+        return ''.join(res)
 
     def decode(self, s: str) -> List[str]:
         if not s:
             return []
         sizes, res, i = [], [], 0
         while s[i] != '#':
-            cur = ""
-            while s[i] != ',':
-                cur += s[i]
-                i += 1
-            sizes.append(int(cur))
-            i += 1
+            j = i
+            while s[j] != ',':
+                j += 1
+            sizes.append(int(s[i:j]))
+            i = j + 1
         i += 1
         for sz in sizes:
             res.append(s[i:i + sz])
@@ -127,16 +125,17 @@ public:
     string encode(vector<string>& strs) {
         if (strs.empty()) return "";
         vector<int> sizes;
-        string res = "";
+        string res;
         for (string& s : strs) {
             sizes.push_back(s.size());
         }
         for (int sz : sizes) {
-            res += to_string(sz) + ',';
+            res.append(to_string(sz));
+            res.push_back(',');
         }
-        res += '#';
+        res.push_back('#');
         for (string& s : strs) {
-            res += s;
+            res.append(s);
         }
         return res;
     }
@@ -147,13 +146,12 @@ public:
         vector<string> res;
         int i = 0;
         while (s[i] != '#') {
-            string cur = "";
-            while (s[i] != ',') {
-                cur += s[i];
-                i++;
+            int j = i;
+            while (s[j] != ',') {
+                j++;
             }
-            sizes.push_back(stoi(cur));
-            i++;
+            sizes.push_back(stoi(s.substr(i, j - i)));
+            i = j + 1;
         }
         i++;
         for (int sz : sizes) {
@@ -174,18 +172,15 @@ class Solution {
     encode(strs) {
         if (strs.length === 0) return '';
         let sizes = [],
-            res = '';
+            parts = [];
         for (let s of strs) {
             sizes.push(s.length);
         }
         for (let sz of sizes) {
-            res += sz + ',';
+            parts.push(String(sz), ',');
         }
-        res += '#';
-        for (let s of strs) {
-            res += s;
-        }
-        return res;
+        parts.push('#', ...strs);
+        return parts.join('');
     }
 
     /**
@@ -198,13 +193,12 @@ class Solution {
             res = [],
             i = 0;
         while (str[i] !== '#') {
-            let cur = '';
-            while (str[i] !== ',') {
-                cur += str[i];
-                i++;
+            let j = i;
+            while (str[j] !== ',') {
+                j++;
             }
-            sizes.push(parseInt(cur));
-            i++;
+            sizes.push(parseInt(str.substring(i, j), 10));
+            i = j + 1;
         }
         i++;
         for (let sz of sizes) {
@@ -222,18 +216,18 @@ public class Solution {
     public string Encode(IList<string> strs) {
         if (strs.Count == 0) return "";
         List<int> sizes = new List<int>();
-        string res = "";
+        StringBuilder res = new StringBuilder();
         foreach (string s in strs) {
             sizes.Add(s.Length);
         }
         foreach (int sz in sizes) {
-            res += sz.ToString() + ',';
+            res.Append(sz).Append(',');
         }
-        res += '#';
+        res.Append('#');
         foreach (string s in strs) {
-            res += s;
+            res.Append(s);
         }
-        return res;
+        return res.ToString();
     }
 
     public List<string> Decode(string s) {
@@ -244,13 +238,12 @@ public class Solution {
         List<string> res = new List<string>();
         int i = 0;
         while (s[i] != '#') {
-            string cur = "";
-            while (s[i] != ',') {
-                cur += s[i];
-                i++;
+            int j = i;
+            while (s[j] != ',') {
+                j++;
             }
-            sizes.Add(int.Parse(cur));
-            i++;
+            sizes.Add(int.Parse(s.Substring(i, j - i)));
+            i = j + 1;
         }
         i++;
         foreach (int sz in sizes) {
@@ -329,21 +322,11 @@ class Solution {
     func encode(_ strs: [String]) -> String {
         if strs.isEmpty { return "" }
 
-        var sizes: [Int] = []
-        var res = ""
+        var sizes: [String] = []
         for s in strs {
-            sizes.append(s.count)
+            sizes.append(String(s.count))
         }
-        for sz in sizes {
-            res += String(sz)
-            res += ","
-        }
-
-        res += "#"
-        for s in strs {
-            res += s
-        }
-        return res
+        return sizes.joined(separator: ",") + ",#" + strs.joined()
     }
 
     func decode(_ s: String) -> [String] {
@@ -354,12 +337,11 @@ class Solution {
         var i = 0
 
         while sArr[i] != "#" {
-            var cur = ""
+            let start = i
             while sArr[i] != "," {
-                cur.append(sArr[i])
                 i += 1
             }
-            sizes.append(Int(cur)!)
+            sizes.append(Int(String(sArr[start..<i]))!)
             i += 1
         }
 
@@ -424,7 +406,7 @@ impl Solution {
 
 ### Time & Space Complexity
 
-- Time complexity: $O(m)$ for each $encode()$ and $decode()$ function calls.
+- Time complexity: $O(m + n)$ for each $encode()$ and $decode()$ function calls.
 - Space complexity: $O(m + n)$ for each $encode()$ and $decode()$ function calls.
 
 > Where $m$ is the sum of lengths of all the strings and $n$ is the number of strings.
@@ -445,10 +427,10 @@ This approach is both simpler and more efficient because it avoids building sepa
 
 #### Encoding
 
-1. Initialize an empty result string.
+1. Initialize an empty result builder (or list of string parts).
 2. For each string in the list:
     - Compute its length.
-    - Append `"length#string"` to the result.
+    - Append `"length#string"` to the builder.
 3. Return the final encoded string.
 
 #### Decoding
@@ -469,10 +451,12 @@ This approach is both simpler and more efficient because it avoids building sepa
 class Solution:
 
     def encode(self, strs: List[str]) -> str:
-        res = ""
+        res = []
         for s in strs:
-            res += str(len(s)) + "#" + s
-        return res
+            res.append(str(len(s)))
+            res.append("#")
+            res.append(s)
+        return "".join(res)
 
     def decode(self, s: str) -> List[str]:
         res = []
@@ -527,7 +511,9 @@ public:
     string encode(vector<string>& strs) {
         string res;
         for (const string& s : strs) {
-            res += to_string(s.size()) + "#" + s;
+            res.append(to_string(s.size()));
+            res.push_back('#');
+            res.append(s);
         }
         return res;
     }
@@ -558,11 +544,11 @@ class Solution {
      * @returns {string}
      */
     encode(strs) {
-        let res = '';
+        const res = [];
         for (let s of strs) {
-            res += s.length + '#' + s;
+            res.push(String(s.length), '#', s);
         }
-        return res;
+        return res.join('');
     }
 
     /**
@@ -591,11 +577,11 @@ class Solution {
 ```csharp
 public class Solution {
     public string Encode(IList<string> strs) {
-        string res = "";
+        StringBuilder res = new StringBuilder();
         foreach (string s in strs) {
-            res += s.Length + "#" + s;
+            res.Append(s.Length).Append('#').Append(s);
         }
-        return res;
+        return res.ToString();
     }
 
     public List<string> Decode(string s) {
@@ -621,11 +607,13 @@ public class Solution {
 type Solution struct{}
 
 func (s *Solution) Encode(strs []string) string {
-	res := ""
+	var res strings.Builder
 	for _, str := range strs {
-		res += strconv.Itoa(len(str)) + "#" + str
+		res.WriteString(strconv.Itoa(len(str)))
+		res.WriteByte('#')
+		res.WriteString(str)
 	}
-	return res
+	return res.String()
 }
 
 func (s *Solution) Decode(encoded string) []string {
@@ -677,11 +665,14 @@ class Solution {
 ```swift
 class Solution {
     func encode(_ strs: [String]) -> String {
-        var res = ""
+        var res: [String] = []
+        res.reserveCapacity(strs.count * 3)
         for s in strs {
-            res += "\(s.count)#\(s)"
+            res.append(String(s.count))
+            res.append("#")
+            res.append(s)
         }
-        return res
+        return res.joined()
     }
 
     func decode(_ s: String) -> [String] {
@@ -745,7 +736,7 @@ impl Solution {
 
 ### Time & Space Complexity
 
-- Time complexity: $O(m)$ for each $encode()$ and $decode()$ function calls.
+- Time complexity: $O(m + n)$ for each $encode()$ and $decode()$ function calls.
 - Space complexity: $O(m + n)$ for each $encode()$ and $decode()$ function calls.
 
 > Where $m$ is the sum of lengths of all the strings and $n$ is the number of strings.

--- a/cpp/0271-encode-and-decode-strings.cpp
+++ b/cpp/0271-encode-and-decode-strings.cpp
@@ -12,11 +12,12 @@ public:
 
     // Encodes a list of strings to a single string.
     string encode(vector<string>& strs) {
-        string result = "";
+        string result;
         
-        for (int i = 0; i < strs.size(); i++) {
-            string str = strs[i];
-            result += to_string(str.size()) + "#" + str;
+        for (const string& str : strs) {
+            result.append(to_string(str.size()));
+            result.push_back('#');
+            result.append(str);
         }
         
         return result;

--- a/python/0271-encode-and-decode-strings.py
+++ b/python/0271-encode-and-decode-strings.py
@@ -1,9 +1,11 @@
 class Solution:
     def encode(self, strs):
-        res = ""
+        res = []
         for s in strs:
-            res += str(len(s)) + "#" + s
-        return res
+            res.append(str(len(s)))
+            res.append("#")
+            res.append(s)
+        return "".join(res)
 
     def decode(self, s):
         res = []

--- a/ruby/0271-encode-and-decode-strings.rb
+++ b/ruby/0271-encode-and-decode-strings.rb
@@ -3,9 +3,7 @@
 # @param {string[]} strs
 # @return {string}
 def encode(strs)
-  strs.reduce("") do |acc, cur|
-    "#{acc}\n#{cur.chars.map { _1.ord.to_s }.join(",")}"
-  end[1..] + "\n"
+  strs.map { |str| "#{str.length}##{str}" }.join
 end
 
 # Decodes a single string to a list of strings.
@@ -13,9 +11,20 @@ end
 # @param {string} s
 # @return {string[]}
 def decode(s)
-  s.each_line.map do |nums|
-    nums[...-1].split(",").map(&:to_i).map(&:chr).join("")
+  res = []
+  i = 0
+
+  while i < s.length
+    j = i
+    j += 1 while s[j] != "#"
+
+    length = s[i...j].to_i
+    start = j + 1
+    res << s[start, length]
+    i = start + length
   end
+
+  res
 end
 
 # Your functions will be called as such:


### PR DESCRIPTION
fixed: solutions that werent running, compialtion errors, clarified write ups

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix user-reported bugs in article content and code examples
> - Corrects `next()`/`hasNext()` time complexity from O(n) to O(1) in [binary-search-tree-iterator.md](https://github.com/neetcode-gh/leetcode/pull/5881/files#diff-ac3382121334bf94696b2d154138200ce8c72a047c8178295105aa7b039c4539)
> - Fixes stale-state checks in Java/C++/JS for [path-with-maximum-probability.md](https://github.com/neetcode-gh/leetcode/pull/5881/files#diff-ee946d26e5b26e67898c1268c2420504d697e722bdda985267781dbb8548d237) from `curr_prob > maxProb[node]` to `curr_prob < maxProb[node]`; updates Rust snippet to use `prob.to_bits()` directly instead of `Reverse((-prob).to_bits())`
> - Rewrites encode/decode implementations in Python, C++, and Ruby to use the `length#string` format with string builders and index-based parsing; updates stated time complexity from O(m) to O(m + n)
> - Adds missing `from math import sqrt` import in [sqrtx.md](https://github.com/neetcode-gh/leetcode/pull/5881/files#diff-442de421b0b04f7cf23b6614c8db786e6d07dadabb23dfb12e14b8b9687c76fa) and fixes various clarifications in `longest-repeating-substring-with-replacement`, `min-cost-climbing-stairs`, and `lemonade-change` articles
> - Risk: The Ruby `encode`/`decode` in [ruby/0271-encode-and-decode-strings.rb](https://github.com/neetcode-gh/leetcode/pull/5881/files#diff-2f3db1af80d56feedb826a1047f3af95e5b2f73502d5ecea86ab99a6c7abe74e) changes the wire format from newline-separated ASCII codes to `length#string` segments, which is a breaking change for any existing encoded data
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2de1029.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->