### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Solutions are also welcome for any other _supported_ language on leetcode.com!
 
 ## Contributing
 
-**Please read the [contributing guidlines](./CONTRIBUTING.md) before opening a PR**
+**Please read the [contributing guidelines](./CONTRIBUTING.md) before opening a PR**
 
 To contribute, please fork this repo and open a PR adding a [missing solution](#missing-solutions) from the supported languages.
 


### PR DESCRIPTION
README.md contained a typo, which I corrected.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix typo in contributing section of README.md
> Corrects a spelling error in [README.md](https://github.com/neetcode-gh/leetcode/pull/5937/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5): 'guidlines' → 'guidelines'.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c8c459.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->