### PR TITLE
Math Rendering Bug in Lemonade Change Article

### DIFF
--- a/articles/lemonade-change.md
+++ b/articles/lemonade-change.md
@@ -2,7 +2,7 @@
 
 Before attempting this problem, you should be comfortable with:
 
-- **Greedy Algorithms** - Making optimal local decisions at each step (prioritizing \$10 bills for \$15 change to preserve flexibility)
+- **Greedy Algorithms** - Making optimal local decisions at each step (prioritizing `$10` bills for `$15` change to preserve flexibility)
 - **Basic Iteration** - Processing elements sequentially while maintaining state
 - **Simple Counting** - Tracking quantities of different bill denominations using variables
 
@@ -561,10 +561,10 @@ impl Solution {
 
 ## Common Pitfalls
 
-### Using Three \$5 Bills Before One \$10 and One \$5
+### Using Three `$5` Bills Before One `$10` and One `$5`
 
-When giving \$15 change for a \$20 bill, you should prefer using one \$10 and one \$5 over three \$5 bills. The \$5 bills are more versatile since they can be used for both \$5 and \$10 change scenarios. Using three \$5 bills depletes your flexibility for future transactions.
+When giving `$15` change for a `$20` bill, you should prefer using one `$10` and one `$5` over three `$5` bills. The `$5` bills are more versatile since they can be used for both `$5` and `$10` change scenarios. Using three `$5` bills depletes your flexibility for future transactions.
 
-### Not Tracking the \$10 Bill Count
+### Not Tracking the `$10` Bill Count
 
-Some solutions only track \$5 bills, assuming \$10 bills are not useful. However, \$10 bills are essential for efficiently making \$15 change. Failing to track them means you cannot implement the optimal greedy strategy and may incorrectly return `false` when change is actually possible.
+Some solutions only track `$5` bills, assuming `$10` bills are not useful. However, `$10` bills are essential for efficiently making `$15` change. Failing to track them means you cannot implement the optimal greedy strategy and may incorrectly return `false` when change is actually possible.


### PR DESCRIPTION
Fixes #6026. Replaces escaped dollar signs \\$\ with inline code blocks \\\\\ to prevent the website's markdown parser from falsely evaluating the text as LaTeX math, which was causing layout/spacing bugs.