### PR TITLE
Fix 14 genuinely-broken article snippets (API misuse + driver-type mismatches)

### DIFF
--- a/articles/clone-graph.md
+++ b/articles/clone-graph.md
@@ -333,17 +333,17 @@ class Solution {
 
 class Solution {
     func cloneGraph(_ node: Node?) -> Node? {
-        var oldToNew = [Node: Node]()
+        var oldToNew = [ObjectIdentifier: Node]()
 
         func dfs(_ node: Node?) -> Node? {
             guard let node = node else { return nil }
 
-            if let existingCopy = oldToNew[node] {
+            if let existingCopy = oldToNew[ObjectIdentifier(node)] {
                 return existingCopy
             }
 
             let copy = Node(node.val)
-            oldToNew[node] = copy
+            oldToNew[ObjectIdentifier(node)] = copy
 
             for neighbor in node.neighbors {
                 if let clonedNeighbor = dfs(neighbor) {
@@ -723,9 +723,9 @@ class Solution {
             return nil
         }
 
-        var oldToNew: [Node: Node] = [:]
+        var oldToNew: [ObjectIdentifier: Node] = [:]
         let newNode = Node(node!.val)
-        oldToNew[node!] = newNode
+        oldToNew[ObjectIdentifier(node!)] = newNode
         var queue = Deque<Node>()
         queue.append(node!)
 
@@ -733,16 +733,16 @@ class Solution {
             let cur = queue.popFirst()!
             for nei in cur.neighbors {
                 if let nei = nei {
-                    if oldToNew[nei] == nil {
-                        oldToNew[nei] = Node(nei.val)
+                    if oldToNew[ObjectIdentifier(nei)] == nil {
+                        oldToNew[ObjectIdentifier(nei)] = Node(nei.val)
                         queue.append(nei)
                     }
-                    oldToNew[cur]!.neighbors.append(oldToNew[nei]!)
+                    oldToNew[ObjectIdentifier(cur)]!.neighbors.append(oldToNew[ObjectIdentifier(nei)]!)
                 }
             }
         }
 
-        return oldToNew[node!]
+        return oldToNew[ObjectIdentifier(node!)]
     }
 }
 ```

--- a/articles/ipo.md
+++ b/articles/ipo.md
@@ -248,7 +248,7 @@ class Solution {
 class Solution {
     func findMaximizedCapital(_ k: Int, _ w: Int, _ profits: [Int], _ capital: [Int]) -> Int {
         var projects = zip(capital, profits).sorted { $0.0 < $1.0 }
-        var maxProfit = Heap<Int>(sort: >)
+        var maxProfit = Heap<Int>()
         var w = w
         var idx = 0
 
@@ -260,7 +260,7 @@ class Solution {
             if maxProfit.isEmpty {
                 break
             }
-            w += maxProfit.remove()!
+            w += maxProfit.popMax()!
         }
 
         return w
@@ -566,19 +566,19 @@ class Solution {
         var indices = Array(0..<capital.count)
         indices.sort { capital[$0] < capital[$1] }
 
-        var maxProfit = Heap<Int>(sort: { profits[$0] > profits[$1] })
+        var maxProfit = Heap<Int>()
         var w = w
         var idx = 0
 
         for _ in 0..<k {
             while idx < indices.count && capital[indices[idx]] <= w {
-                maxProfit.insert(indices[idx])
+                maxProfit.insert(profits[indices[idx]])
                 idx += 1
             }
             if maxProfit.isEmpty {
                 break
             }
-            w += profits[maxProfit.remove()!]
+            w += maxProfit.popMax()!
         }
 
         return w
@@ -869,7 +869,7 @@ class Solution {
         let n = profits.count
         let indices = (0..<n).sorted { capital[$0] < capital[$1] }
 
-        var maxProfit = Heap<Int>(sort: >)
+        var maxProfit = Heap<Int>()
         var w = w
         var idx = 0
 
@@ -881,7 +881,7 @@ class Solution {
             if maxProfit.isEmpty {
                 break
             }
-            w += maxProfit.remove()!
+            w += maxProfit.popMax()!
         }
 
         return w

--- a/articles/meeting-schedule-ii.md
+++ b/articles/meeting-schedule-ii.md
@@ -224,10 +224,10 @@ func minMeetingRooms(intervals []Interval) int {
 
 class Solution {
     fun minMeetingRooms(intervals: List<Interval>): Int {
-        intervals.sortBy { it.start }
+        val sortedIntervals = intervals.sortedBy { it.start }
 
         val minHeap = PriorityQueue<Int>()
-        for (interval in intervals) {
+        for (interval in sortedIntervals) {
             if (minHeap.isNotEmpty() && minHeap.peek() <= interval.start) {
                 minHeap.poll()
             }
@@ -257,7 +257,7 @@ class Solution {
         let sortedIntervals = intervals.sorted { $0.start < $1.start }
         var minHeap = Heap<Int>()
         for interval in sortedIntervals {
-            if !minHeap.isEmpty, let earliest = minHeap.min!, earliest <= interval.start {
+            if let earliest = minHeap.min, earliest <= interval.start {
                 minHeap.removeMin()
             }
             minHeap.insert(interval.end)
@@ -269,18 +269,18 @@ class Solution {
 
 ```rust
 impl Solution {
-    pub fn min_meeting_rooms(intervals: Vec<Vec<i32>>) -> i32 {
+    pub fn min_meeting_rooms(intervals: Vec<Interval>) -> i32 {
         let mut intervals = intervals;
-        intervals.sort_by_key(|v| v[0]);
+        intervals.sort_by_key(|v| v.start);
         let mut min_heap = BinaryHeap::new();
 
         for interval in &intervals {
             if let Some(&Reverse(top)) = min_heap.peek() {
-                if top <= interval[0] {
+                if top <= interval.start {
                     min_heap.pop();
                 }
             }
-            min_heap.push(Reverse(interval[1]));
+            min_heap.push(Reverse(interval.end));
         }
 
         min_heap.len() as i32
@@ -575,11 +575,11 @@ class Solution {
 
 ```rust
 impl Solution {
-    pub fn min_meeting_rooms(intervals: Vec<Vec<i32>>) -> i32 {
+    pub fn min_meeting_rooms(intervals: Vec<Interval>) -> i32 {
         let mut mp = BTreeMap::new();
         for i in &intervals {
-            *mp.entry(i[0]).or_insert(0) += 1;
-            *mp.entry(i[1]).or_insert(0) -= 1;
+            *mp.entry(i.start).or_insert(0) += 1;
+            *mp.entry(i.end).or_insert(0) -= 1;
         }
         let mut prev = 0;
         let mut res = 0;
@@ -946,10 +946,10 @@ class Solution {
 
 ```rust
 impl Solution {
-    pub fn min_meeting_rooms(intervals: Vec<Vec<i32>>) -> i32 {
+    pub fn min_meeting_rooms(intervals: Vec<Interval>) -> i32 {
         let n = intervals.len();
-        let mut starts: Vec<i32> = intervals.iter().map(|v| v[0]).collect();
-        let mut ends: Vec<i32> = intervals.iter().map(|v| v[1]).collect();
+        let mut starts: Vec<i32> = intervals.iter().map(|v| v.start).collect();
+        let mut ends: Vec<i32> = intervals.iter().map(|v| v.end).collect();
         starts.sort();
         ends.sort();
 
@@ -1226,7 +1226,7 @@ func minMeetingRooms(intervals []Interval) int {
  */
 
 class Solution {
-    fun minMeetingRooms(intervals: Array<IntArray>): Int {
+    fun minMeetingRooms(intervals: List<Interval>): Int {
         val time = mutableListOf<Pair<Int, Int>>()
 
         for (i in intervals) {
@@ -1293,11 +1293,11 @@ class Solution {
 
 ```rust
 impl Solution {
-    pub fn min_meeting_rooms(intervals: Vec<Vec<i32>>) -> i32 {
+    pub fn min_meeting_rooms(intervals: Vec<Interval>) -> i32 {
         let mut time: Vec<(i32, i32)> = Vec::new();
         for i in &intervals {
-            time.push((i[0], 1));
-            time.push((i[1], -1));
+            time.push((i.start, 1));
+            time.push((i.end, -1));
         }
 
         time.sort();

--- a/articles/meeting-schedule.md
+++ b/articles/meeting-schedule.md
@@ -276,12 +276,12 @@ class Solution {
 
 ```rust
 impl Solution {
-    pub fn can_attend_meetings(intervals: Vec<Vec<i32>>) -> bool {
+    pub fn can_attend_meetings(intervals: Vec<Interval>) -> bool {
         let n = intervals.len();
         for i in 0..n {
             for j in (i + 1)..n {
-                if intervals[i][1].min(intervals[j][1])
-                    > intervals[i][0].max(intervals[j][0])
+                if intervals[i].end.min(intervals[j].end)
+                    > intervals[i].start.max(intervals[j].start)
                 {
                     return false;
                 }
@@ -544,12 +544,12 @@ class Solution {
 
 ```rust
 impl Solution {
-    pub fn can_attend_meetings(intervals: Vec<Vec<i32>>) -> bool {
+    pub fn can_attend_meetings(intervals: Vec<Interval>) -> bool {
         let mut intervals = intervals;
-        intervals.sort_by_key(|v| v[0]);
+        intervals.sort_by_key(|v| v.start);
 
         for i in 1..intervals.len() {
-            if intervals[i - 1][1] > intervals[i][0] {
+            if intervals[i - 1].end > intervals[i].start {
                 return false;
             }
         }


### PR DESCRIPTION
## Scope

Fixes the 14 article snippets that are genuinely broken against the NC-Judge drivers. An earlier revision of this branch also added `import Collections` to 54 Swift snippets; that was dropped after a decision change — swift-collections is being made ambient at the **driver level** in the main repo, so those snippets were correct as written and need no edit.

## What's fixed (14 snippets, 4 articles)

### swift-collections API misuse (4)
- **ipo** — Two Heaps, Two Heaps (Optimal), Sorting + Max-Heap (Swift): `Heap<Int>(sort:)` and `.remove()` don't exist; swift-collections `Heap` is a min-max heap, so use `Heap<Int>()` + `.popMax()`. The "Two Heaps (Optimal)" variant now heaps profit values directly instead of heaping indices under a comparator the type doesn't support.
- **meeting-schedule-ii** — Min Heap (Swift): `if let earliest = minHeap.min!` bound a non-optional (compile error); force-unwrap dropped.

### Driver signature mismatches (10)
- **meeting-schedule-ii** — 4 Rust tabs: driver passes `Vec<Interval>`, not `Vec<Vec<i32>>`; use `.start` / `.end`.
- **meeting-schedule-ii** — 2 Kotlin tabs: Min Heap called `sortBy` on a read-only `List` (now `sortedBy`); Greedy declared `Array<IntArray>` instead of `List<Interval>`.
- **meeting-schedule** — 2 Rust tabs: same `Vec<Interval>` mismatch.
- **clone-graph** — 2 Swift tabs (DFS, BFS): dictionary keyed by the non-Hashable `Node`; now keyed by `ObjectIdentifier`.

## Verification against the production judge

| Fix | Result |
| --- | --- |
| meeting-schedule Rust (Brute Force, Sorting) | PASS (25/25 each) |
| meeting-schedule-ii Rust (Min Heap, Sweep Line, Two Pointers, Greedy) | PASS (24/24 each) |
| meeting-schedule-ii Kotlin (Min Heap, Greedy — plus other 2 tabs) | PASS (24/24 each) |
| clone-graph Swift DFS | PASS (18/18) |
| clone-graph Swift BFS | Pending driver rollout — fails only on `cannot find 'Deque' in scope` (uses `Deque`; ObjectIdentifier fix verified compile-clean past that point) |
| ipo Swift × 3 | Pending driver rollout — each fails only on `cannot find 'Heap' in scope`; the old `Heap(sort:)` / `.remove()` errors are gone |
| meeting-schedule-ii Swift Min Heap | Pending driver rollout — fails only on `cannot find 'Heap' in scope` |

## Pending on other rollouts (intentionally untouched)

- **Driver-level `import Collections` (main repo)**: unblocks the 5 pending Swift snippets above (ipo × 3, meeting-schedule-ii Min Heap, clone-graph BFS) and the 54 snippets that were reverted from this PR.
- **nc-judge gods deploy**: meeting-schedule-ii Min Heap (Go, `gods` priorityqueue) and trapping-rain-water Stack (Go, `gods` linkedliststack) remain failing until the judge image ships with gods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)