### PR TITLE
fix: remove Go import lines from article code blocks (judge compatibility)

### DIFF
--- a/articles/design-compressed-string-iterator.md
+++ b/articles/design-compressed-string-iterator.md
@@ -547,8 +547,6 @@ public class StringIterator {
 ```
 
 ```go
-import "regexp"
-
 type StringIterator struct {
     ptr   int
     chars []byte

--- a/articles/final-array-state-after-k-multiplication-operations-i.md
+++ b/articles/final-array-state-after-k-multiplication-operations-i.md
@@ -345,8 +345,6 @@ public class Solution {
 ```
 
 ```go
-import "container/heap"
-
 type MinHeap struct {
     indices []int
     values  []int

--- a/articles/find-the-difference.md
+++ b/articles/find-the-difference.md
@@ -112,7 +112,7 @@ public class Solution {
 ```
 
 ```go
-func findTheDifference(s string, t string) byte {
+func findTheDifference(s string, t string) string {
     countS := make([]int, 26)
     countT := make([]int, 26)
 
@@ -125,10 +125,10 @@ func findTheDifference(s string, t string) byte {
 
     for i := 0; i < 26; i++ {
         if countT[i] > countS[i] {
-            return byte('a' + i)
+            return string(rune('a' + i))
         }
     }
-    return ' '
+    return " "
 }
 ```
 
@@ -308,7 +308,7 @@ public class Solution {
 ```
 
 ```go
-func findTheDifference(s string, t string) byte {
+func findTheDifference(s string, t string) string {
     count := make([]int, 26)
 
     for _, c := range t {
@@ -320,10 +320,10 @@ func findTheDifference(s string, t string) byte {
 
     for i := 0; i < 26; i++ {
         if count[i] == 1 {
-            return byte('a' + i)
+            return string(rune('a' + i))
         }
     }
-    return ' '
+    return " "
 }
 ```
 
@@ -492,9 +492,7 @@ public class Solution {
 ```
 
 ```go
-import "sort"
-
-func findTheDifference(s string, t string) byte {
+func findTheDifference(s string, t string) string {
     sArr := []byte(s)
     tArr := []byte(t)
     sort.Slice(sArr, func(i, j int) bool { return sArr[i] < sArr[j] })
@@ -502,10 +500,10 @@ func findTheDifference(s string, t string) byte {
 
     for i := 0; i < len(sArr); i++ {
         if sArr[i] != tArr[i] {
-            return tArr[i]
+            return string(tArr[i])
         }
     }
-    return tArr[len(tArr)-1]
+    return string(tArr[len(tArr)-1])
 }
 ```
 
@@ -662,7 +660,7 @@ public class Solution {
 ```
 
 ```go
-func findTheDifference(s string, t string) byte {
+func findTheDifference(s string, t string) string {
     sumS, sumT := 0, 0
     for _, c := range s {
         sumS += int(c)
@@ -670,7 +668,7 @@ func findTheDifference(s string, t string) byte {
     for _, c := range t {
         sumT += int(c)
     }
-    return byte(sumT - sumS)
+    return string(rune(sumT - sumS))
 }
 ```
 
@@ -817,7 +815,7 @@ public class Solution {
 ```
 
 ```go
-func findTheDifference(s string, t string) byte {
+func findTheDifference(s string, t string) string {
     res := 0
     for _, c := range s {
         res -= int(c)
@@ -825,7 +823,7 @@ func findTheDifference(s string, t string) byte {
     for _, c := range t {
         res += int(c)
     }
-    return byte(res)
+    return string(rune(res))
 }
 ```
 
@@ -972,7 +970,7 @@ public class Solution {
 ```
 
 ```go
-func findTheDifference(s string, t string) byte {
+func findTheDifference(s string, t string) string {
     res := 0
     for _, c := range s {
         res ^= int(c)
@@ -980,7 +978,7 @@ func findTheDifference(s string, t string) byte {
     for _, c := range t {
         res ^= int(c)
     }
-    return byte(res)
+    return string(rune(res))
 }
 ```
 

--- a/articles/high-five.md
+++ b/articles/high-five.md
@@ -428,11 +428,6 @@ class Solution {
 ```
 
 ```go
-import (
-    "container/heap"
-    "sort"
-)
-
 type MaxHeap []int
 
 func (h MaxHeap) Len() int           { return len(h) }
@@ -738,11 +733,6 @@ class Solution {
 ```
 
 ```go
-import (
-    "container/heap"
-    "sort"
-)
-
 type MinHeap []int
 
 func (h MinHeap) Len() int           { return len(h) }

--- a/articles/ipo.md
+++ b/articles/ipo.md
@@ -165,10 +165,6 @@ public class Solution {
 ```
 
 ```go
-import (
-    "container/heap"
-)
-
 type MinCapitalHeap [][]int
 func (h MinCapitalHeap) Len() int           { return len(h) }
 func (h MinCapitalHeap) Less(i, j int) bool { return h[i][0] < h[j][0] }
@@ -473,10 +469,6 @@ public class Solution {
 ```
 
 ```go
-import (
-    "container/heap"
-)
-
 type MinCapitalHeap struct {
     indices []int
     capital []int
@@ -791,11 +783,6 @@ public class Solution {
 ```
 
 ```go
-import (
-    "container/heap"
-    "sort"
-)
-
 type MaxHeap []int
 
 func (h MaxHeap) Len() int           { return len(h) }

--- a/articles/longest-common-prefix.md
+++ b/articles/longest-common-prefix.md
@@ -488,8 +488,6 @@ public class Solution {
 ```
 
 ```go
-import "sort"
-
 func longestCommonPrefix(strs []string) string {
     if len(strs) == 1 {
         return strs[0]

--- a/articles/longest-happy-string.md
+++ b/articles/longest-happy-string.md
@@ -594,8 +594,6 @@ public class Solution {
 ```
 
 ```go
-import "container/heap"
-
 type MaxHeap [][]int
 
 func (h MaxHeap) Len() int           { return len(h) }

--- a/articles/max-stack.md
+++ b/articles/max-stack.md
@@ -851,10 +851,6 @@ public class MaxStack {
 ```
 
 ```go
-import (
-    "container/heap"
-)
-
 type MaxHeap [][2]int
 
 func (h MaxHeap) Len() int { return len(h) }

--- a/articles/maximum-frequency-stack.md
+++ b/articles/maximum-frequency-stack.md
@@ -475,8 +475,6 @@ public class FreqStack {
 ```
 
 ```go
-import "container/heap"
-
 type Entry struct {
     freq  int
     index int

--- a/articles/my-calendar-i.md
+++ b/articles/my-calendar-i.md
@@ -803,8 +803,6 @@ public class MyCalendar {
 ```
 
 ```go
-import "sort"
-
 type MyCalendar struct {
     events [][2]int
 }

--- a/articles/path-with-maximum-probability.md
+++ b/articles/path-with-maximum-probability.md
@@ -230,10 +230,6 @@ public class Solution {
 ```
 
 ```go
-import (
-    "container/heap"
-)
-
 type Pair struct {
     node int
     prob float64
@@ -657,10 +653,6 @@ public class Solution {
 ```
 
 ```go
-import (
-    "container/heap"
-)
-
 type Pair struct {
     node int
     prob float64

--- a/articles/path-with-minimum-effort.md
+++ b/articles/path-with-minimum-effort.md
@@ -241,10 +241,6 @@ public class Solution {
 ```
 
 ```go
-import (
-    "container/heap"
-)
-
 type Item struct {
     diff, r, c int
 }

--- a/articles/remove-sub-folders-from-the-filesystem.md
+++ b/articles/remove-sub-folders-from-the-filesystem.md
@@ -337,8 +337,6 @@ public class Solution {
 ```
 
 ```go
-import "sort"
-
 func removeSubfolders(folder []string) []string {
     sort.Strings(folder)
     res := []string{folder[0]}
@@ -699,8 +697,6 @@ public class Solution {
 ```
 
 ```go
-import "strings"
-
 type Trie struct {
     children     map[string]*Trie
     endOfFolder  bool

--- a/articles/reorganize-string.md
+++ b/articles/reorganize-string.md
@@ -656,8 +656,6 @@ public class Solution {
 ```
 
 ```go
-import "container/heap"
-
 type MaxHeap [][]int
 
 func (h MaxHeap) Len() int           { return len(h) }

--- a/articles/search-insert-position.md
+++ b/articles/search-insert-position.md
@@ -835,8 +835,6 @@ public class Solution {
 ```
 
 ```go
-import "sort"
-
 func searchInsert(nums []int, target int) int {
     return sort.SearchInts(nums, target)
 }


### PR DESCRIPTION
## Summary

On the NeetCode judge, article Go snippets are spliced into a driver that already declares `package main` and the needed imports. Any `import` line inside the snippet causes a compilation error (`redeclared in this block` / `imported and not used`), so hitting **Run** on these articles' Go solutions failed for users.

- Removes `import` lines from 21 Go blocks across 15 articles (only problems that have Go judge support — articles without a Go judge directory are untouched, since imports there are harmless and help readers running locally).
- `find-the-difference`: also converts the Go solutions from `byte` to `string` returns to match the NeetCode judge signature — all 6 approaches failed to compile on the judge regardless of imports.

## Verification

Every Go approach in all 15 articles passes the article harness (`test-problem-article-solutions.ts --lang go`) against the local judge:

| Article | Go approaches |
|---|---|
| design-compressed-string-iterator | 2/3* |
| final-array-state-after-k-multiplication-operations-i | 2/2 |
| find-the-difference | 6/6 |
| high-five | 3/3 |
| ipo | 3/3 |
| longest-common-prefix | 4/4 |
| longest-happy-string | 3/3 |
| max-stack | 2/2 |
| maximum-frequency-stack | 4/4 |
| my-calendar-i | 3/3 |
| path-with-maximum-probability | 4/4 |
| path-with-minimum-effort | 4/4 |
| remove-sub-folders-from-the-filesystem | 3/3 |
| reorganize-string | 3/3 |
| search-insert-position | 5/5 |

\* the third approach is titled "(Time Limit Exceeded)" and is intentionally inefficient — it OOMs on the judge by design.

high-five and max-stack verification also required two judge-driver fixes on the neetcode.io side (submitted separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)