### PR TITLE
fix: repair all article solutions that deterministically fail on the NC judge

### DIFF
--- a/articles/binary-tree-diameter.md
+++ b/articles/binary-tree-diameter.md
@@ -1002,21 +1002,19 @@ func diameterOfBinaryTree(root *TreeNode) int {
        return 0
    }
 
-   stack := linkedliststack.New()
-   stack.Push(root)
+   stack := []*TreeNode{root}
    mp := make(map[*TreeNode][]int)
    mp[nil] = []int{0, 0}
 
-   for !stack.Empty() {
-       val, _ := stack.Peek()
-       node := val.(*TreeNode)
+   for len(stack) > 0 {
+       node := stack[len(stack)-1]
 
        if node.Left != nil && len(mp[node.Left]) == 0 {
-           stack.Push(node.Left)
+           stack = append(stack, node.Left)
        } else if node.Right != nil && len(mp[node.Right]) == 0 {
-           stack.Push(node.Right)
+           stack = append(stack, node.Right)
        } else {
-           stack.Pop()
+           stack = stack[:len(stack)-1]
 
            leftHeight := mp[node.Left][0]
            leftDiameter := mp[node.Left][1]

--- a/articles/cheapest-flight-path.md
+++ b/articles/cheapest-flight-path.md
@@ -224,6 +224,20 @@ public class Solution {
 ```
 
 ```go
+type MinHeap [][3]int
+
+func (h MinHeap) Len() int            { return len(h) }
+func (h MinHeap) Less(i, j int) bool  { return h[i][0] < h[j][0] }
+func (h MinHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MinHeap) Push(x interface{}) { *h = append(*h, x.([3]int)) }
+func (h *MinHeap) Pop() interface{} {
+    old := *h
+    n := len(old)
+    x := old[n-1]
+    *h = old[:n-1]
+    return x
+}
+
 func findCheapestPrice(n int, flights [][]int, src int, dst int, k int) int {
     INF := 1000000000
     adj := make([][]struct{ to, cost int }, n)
@@ -239,13 +253,12 @@ func findCheapestPrice(n int, flights [][]int, src int, dst int, k int) int {
         adj[from] = append(adj[from], struct{ to, cost int }{to, cost})
     }
     dist[src][0] = 0
-    minHeap := priorityqueue.NewWith(func(a, b interface{}) int {
-        return utils.IntComparator(a.([3]int)[0], b.([3]int)[0])
-    })
-    minHeap.Enqueue([3]int{0, src, -1})
-    for !minHeap.Empty() {
-        value, _ := minHeap.Dequeue()
-        cst, node, stops := value.([3]int)[0], value.([3]int)[1], value.([3]int)[2]
+    minHeap := &MinHeap{}
+    heap.Init(minHeap)
+    heap.Push(minHeap, [3]int{0, src, -1})
+    for minHeap.Len() > 0 {
+        value := heap.Pop(minHeap).([3]int)
+        cst, node, stops := value[0], value[1], value[2]
         if node == dst {
             return cst
         }
@@ -257,7 +270,7 @@ func findCheapestPrice(n int, flights [][]int, src int, dst int, k int) int {
             nextStops := stops + 1
             if dist[nei.to][nextStops+1] > nextCst {
                 dist[nei.to][nextStops+1] = nextCst
-                minHeap.Enqueue([3]int{nextCst, nei.to, nextStops})
+                heap.Push(minHeap, [3]int{nextCst, nei.to, nextStops})
             }
         }
     }

--- a/articles/copy-linked-list-with-random-pointer.md
+++ b/articles/copy-linked-list-with-random-pointer.md
@@ -295,19 +295,28 @@ class Solution {
 ```
 
 ```rust
-// Note: LeetCode does not support Rust for this problem.
-// Below is an index-based approach using HashMap.
-// Definition for a Node:
-// struct Node { val: i32, next: Option<usize>, random: Option<usize> }
 impl Solution {
-    pub fn copy_random_list(head: &Vec<(i32, Option<usize>)>) -> Vec<(i32, Option<usize>)> {
-        // head is represented as Vec<(val, random_index)>
-        // where random_index is the index of the random pointer node
-        let mut result = Vec::new();
-        for &(val, random) in head.iter() {
-            result.push((val, random));
+    pub fn copy_random_list(head: Option<Rc<RefCell<Node>>>) -> Option<Rc<RefCell<Node>>> {
+        fn dfs(
+            node: &Option<Rc<RefCell<Node>>>,
+            old_to_copy: &mut HashMap<*const RefCell<Node>, Rc<RefCell<Node>>>,
+        ) -> Option<Rc<RefCell<Node>>> {
+            let node = node.as_ref()?;
+            let key = Rc::as_ptr(node);
+            if let Some(copy) = old_to_copy.get(&key) {
+                return Some(copy.clone());
+            }
+            let copy = Rc::new(RefCell::new(Node::new(node.borrow().val)));
+            old_to_copy.insert(key, copy.clone());
+            let next = dfs(&node.borrow().next, old_to_copy);
+            copy.borrow_mut().next = next;
+            let random = dfs(&node.borrow().random, old_to_copy);
+            copy.borrow_mut().random = random;
+            Some(copy)
         }
-        result
+
+        let mut old_to_copy = HashMap::new();
+        dfs(&head, &mut old_to_copy)
     }
 }
 ```
@@ -649,21 +658,28 @@ class Solution {
 ```
 
 ```rust
-// Note: LeetCode does not support Rust for this problem.
-// Below is an index-based two-pass approach.
 impl Solution {
-    pub fn copy_random_list(head: &Vec<(i32, Option<usize>)>) -> Vec<(i32, Option<usize>)> {
-        let n = head.len();
-        let mut copy = Vec::with_capacity(n);
-        // Pass 1: copy values
-        for &(val, _) in head.iter() {
-            copy.push((val, None));
+    pub fn copy_random_list(head: Option<Rc<RefCell<Node>>>) -> Option<Rc<RefCell<Node>>> {
+        let mut old_to_copy: HashMap<*const RefCell<Node>, Rc<RefCell<Node>>> = HashMap::new();
+
+        let mut cur = head.clone();
+        while let Some(node) = cur {
+            let copy = Rc::new(RefCell::new(Node::new(node.borrow().val)));
+            old_to_copy.insert(Rc::as_ptr(&node), copy);
+            cur = node.borrow().next.clone();
         }
-        // Pass 2: set random pointers
-        for i in 0..n {
-            copy[i].1 = head[i].1;
+
+        let mut cur = head.clone();
+        while let Some(node) = cur {
+            let copy = old_to_copy[&Rc::as_ptr(&node)].clone();
+            let next = node.borrow().next.as_ref().map(|n| old_to_copy[&Rc::as_ptr(n)].clone());
+            copy.borrow_mut().next = next;
+            let random = node.borrow().random.as_ref().map(|n| old_to_copy[&Rc::as_ptr(n)].clone());
+            copy.borrow_mut().random = random;
+            cur = node.borrow().next.clone();
         }
-        copy
+
+        head.as_ref().map(|n| old_to_copy[&Rc::as_ptr(n)].clone())
     }
 }
 ```
@@ -1028,11 +1044,33 @@ class Solution {
 ```
 
 ```rust
-// Note: LeetCode does not support Rust for this problem.
-// Below is an index-based one-pass approach.
 impl Solution {
-    pub fn copy_random_list(head: &Vec<(i32, Option<usize>)>) -> Vec<(i32, Option<usize>)> {
-        head.clone()
+    pub fn copy_random_list(head: Option<Rc<RefCell<Node>>>) -> Option<Rc<RefCell<Node>>> {
+        fn get_copy(
+            node: &Option<Rc<RefCell<Node>>>,
+            old_to_copy: &mut HashMap<*const RefCell<Node>, Rc<RefCell<Node>>>,
+        ) -> Option<Rc<RefCell<Node>>> {
+            let node = node.as_ref()?;
+            let copy = old_to_copy
+                .entry(Rc::as_ptr(node))
+                .or_insert_with(|| Rc::new(RefCell::new(Node::new(node.borrow().val))))
+                .clone();
+            Some(copy)
+        }
+
+        let mut old_to_copy: HashMap<*const RefCell<Node>, Rc<RefCell<Node>>> = HashMap::new();
+
+        let mut cur = head.clone();
+        while let Some(node) = cur {
+            let copy = get_copy(&Some(node.clone()), &mut old_to_copy).unwrap();
+            let next = get_copy(&node.borrow().next, &mut old_to_copy);
+            copy.borrow_mut().next = next;
+            let random = get_copy(&node.borrow().random, &mut old_to_copy);
+            copy.borrow_mut().random = random;
+            cur = node.borrow().next.clone();
+        }
+
+        get_copy(&head, &mut old_to_copy)
     }
 }
 ```
@@ -1495,10 +1533,45 @@ class Solution {
 ```
 
 ```rust
-// Note: LeetCode does not support Rust for this problem.
-// The interleaving approach cannot be directly translated
-// to safe Rust due to shared mutable references.
-// See the Hash Map approaches above for Rust solutions.
+impl Solution {
+    pub fn copy_random_list(head: Option<Rc<RefCell<Node>>>) -> Option<Rc<RefCell<Node>>> {
+        head.as_ref()?;
+
+        let mut cur = head.clone();
+        while let Some(node) = cur {
+            let next = node.borrow().next.clone();
+            let copy = Rc::new(RefCell::new(Node::new(node.borrow().val)));
+            copy.borrow_mut().next = next.clone();
+            node.borrow_mut().next = Some(copy);
+            cur = next;
+        }
+
+        let mut cur = head.clone();
+        while let Some(node) = cur {
+            let copy = node.borrow().next.clone().unwrap();
+            let random_copy = node
+                .borrow()
+                .random
+                .as_ref()
+                .map(|r| r.borrow().next.clone().unwrap());
+            copy.borrow_mut().random = random_copy;
+            cur = copy.borrow().next.clone();
+        }
+
+        let new_head = head.as_ref().unwrap().borrow().next.clone();
+        let mut cur = head.clone();
+        while let Some(node) = cur {
+            let copy = node.borrow().next.clone().unwrap();
+            let next = copy.borrow().next.clone();
+            node.borrow_mut().next = next.clone();
+            let copy_next = next.as_ref().map(|n| n.borrow().next.clone().unwrap());
+            copy.borrow_mut().next = copy_next;
+            cur = next;
+        }
+
+        new_head
+    }
+}
 ```
 
 ::tabs-end
@@ -1954,10 +2027,45 @@ class Solution {
 ```
 
 ```rust
-// Note: LeetCode does not support Rust for this problem.
-// The random-pointer-based interleaving approach cannot
-// be directly translated to safe Rust.
-// See the Hash Map approaches above for Rust solutions.
+impl Solution {
+    pub fn copy_random_list(head: Option<Rc<RefCell<Node>>>) -> Option<Rc<RefCell<Node>>> {
+        head.as_ref()?;
+
+        let mut cur = head.clone();
+        while let Some(node) = cur {
+            let copy = Rc::new(RefCell::new(Node::new(node.borrow().val)));
+            copy.borrow_mut().next = node.borrow().random.clone();
+            node.borrow_mut().random = Some(copy);
+            cur = node.borrow().next.clone();
+        }
+
+        let mut cur = head.clone();
+        while let Some(node) = cur {
+            let copy = node.borrow().random.clone().unwrap();
+            let random_copy = copy
+                .borrow()
+                .next
+                .as_ref()
+                .map(|orig_random| orig_random.borrow().random.clone().unwrap());
+            copy.borrow_mut().random = random_copy;
+            cur = node.borrow().next.clone();
+        }
+
+        let new_head = head.as_ref().unwrap().borrow().random.clone();
+        let mut cur = head.clone();
+        while let Some(node) = cur {
+            let copy = node.borrow().random.clone().unwrap();
+            let next = node.borrow().next.clone();
+            let orig_random = copy.borrow().next.clone();
+            node.borrow_mut().random = orig_random;
+            let copy_next = next.as_ref().map(|n| n.borrow().random.clone().unwrap());
+            copy.borrow_mut().next = copy_next;
+            cur = next;
+        }
+
+        new_head
+    }
+}
 ```
 
 ::tabs-end

--- a/articles/depth-of-binary-tree.md
+++ b/articles/depth-of-binary-tree.md
@@ -870,22 +870,21 @@ func maxDepth(root *TreeNode) int {
        return 0
    }
 
-   q := linkedlistqueue.New()
-   q.Enqueue(root)
+   q := []*TreeNode{root}
    level := 0
 
-   for !q.Empty() {
-       size := q.Size()
+   for len(q) > 0 {
+       size := len(q)
 
        for i := 0; i < size; i++ {
-           val, _ := q.Dequeue()
-           node := val.(*TreeNode)
+           node := q[0]
+           q = q[1:]
 
            if node.Left != nil {
-               q.Enqueue(node.Left)
+               q = append(q, node.Left)
            }
            if node.Right != nil {
-               q.Enqueue(node.Right)
+               q = append(q, node.Right)
            }
        }
        level++

--- a/articles/design-a-leaderboard.md
+++ b/articles/design-a-leaderboard.md
@@ -551,8 +551,6 @@ public class Leaderboard {
 ```
 
 ```go
-import "container/heap"
-
 type MinHeap []int
 
 func (h MinHeap) Len() int           { return len(h) }
@@ -1062,64 +1060,72 @@ public class Leaderboard {
 ```
 
 ```go
+// Go has no ordered map in its standard library, so the sorted map is
+// modeled with a count map plus a slice of the distinct scores kept in
+// descending order (binary searched with sort.Search).
 type Leaderboard struct {
     scores       map[int]int
-    sortedScores *redblacktree.Tree
+    scoreCount   map[int]int
+    sortedScores []int
 }
 
 func Constructor() Leaderboard {
     return Leaderboard{
         scores:       make(map[int]int),
-        sortedScores: redblacktree.NewWith(func(a, b interface{}) int {
-            return b.(int) - a.(int)
-        }),
+        scoreCount:   make(map[int]int),
+        sortedScores: []int{},
+    }
+}
+
+func (this *Leaderboard) findIndex(score int) int {
+    return sort.Search(len(this.sortedScores), func(i int) bool {
+        return this.sortedScores[i] <= score
+    })
+}
+
+func (this *Leaderboard) put(score int) {
+    this.scoreCount[score]++
+    if this.scoreCount[score] == 1 {
+        i := this.findIndex(score)
+        this.sortedScores = append(this.sortedScores, 0)
+        copy(this.sortedScores[i+1:], this.sortedScores[i:])
+        this.sortedScores[i] = score
+    }
+}
+
+func (this *Leaderboard) remove(score int) {
+    playerCount := this.scoreCount[score]
+    if playerCount == 0 {
+        return
+    }
+    if playerCount == 1 {
+        delete(this.scoreCount, score)
+        i := this.findIndex(score)
+        this.sortedScores = append(this.sortedScores[:i], this.sortedScores[i+1:]...)
+    } else {
+        this.scoreCount[score] = playerCount - 1
     }
 }
 
 func (this *Leaderboard) AddScore(playerId int, score int) {
     if _, exists := this.scores[playerId]; !exists {
         this.scores[playerId] = score
-        count := 0
-        if val, found := this.sortedScores.Get(score); found {
-            count = val.(int)
-        }
-        this.sortedScores.Put(score, count+1)
+        this.put(score)
     } else {
         preScore := this.scores[playerId]
-        playerCount := this.sortedScores.Values()[this.findIndex(preScore)].(int)
-
-        if playerCount == 1 {
-            this.sortedScores.Remove(preScore)
-        } else {
-            this.sortedScores.Put(preScore, playerCount-1)
-        }
+        this.remove(preScore)
 
         newScore := preScore + score
         this.scores[playerId] = newScore
-        count := 0
-        if val, found := this.sortedScores.Get(newScore); found {
-            count = val.(int)
-        }
-        this.sortedScores.Put(newScore, count+1)
+        this.put(newScore)
     }
-}
-
-func (this *Leaderboard) findIndex(score int) int {
-    for i, k := range this.sortedScores.Keys() {
-        if k.(int) == score {
-            return i
-        }
-    }
-    return -1
 }
 
 func (this *Leaderboard) Top(K int) int {
     count, sum := 0, 0
-    it := this.sortedScores.Iterator()
 
-    for it.Next() {
-        key := it.Key().(int)
-        times := it.Value().(int)
+    for _, key := range this.sortedScores {
+        times := this.scoreCount[key]
 
         for i := 0; i < times; i++ {
             sum += key
@@ -1134,16 +1140,10 @@ func (this *Leaderboard) Top(K int) int {
 }
 
 func (this *Leaderboard) Reset(playerId int) {
-    preScore := this.scores[playerId]
-    if val, found := this.sortedScores.Get(preScore); found {
-        playerCount := val.(int)
-        if playerCount == 1 {
-            this.sortedScores.Remove(preScore)
-        } else {
-            this.sortedScores.Put(preScore, playerCount-1)
-        }
+    if preScore, exists := this.scores[playerId]; exists {
+        this.remove(preScore)
+        delete(this.scores, playerId)
     }
-    delete(this.scores, playerId)
 }
 ```
 

--- a/articles/design-twitter-feed.md
+++ b/articles/design-twitter-feed.md
@@ -837,6 +837,20 @@ class Twitter {
 ```
 
 ```go
+type MinHeap [][]int
+
+func (h MinHeap) Len() int            { return len(h) }
+func (h MinHeap) Less(i, j int) bool  { return h[i][0] < h[j][0] }
+func (h MinHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MinHeap) Push(x interface{}) { *h = append(*h, x.([]int)) }
+func (h *MinHeap) Pop() interface{} {
+    old := *h
+    n := len(old)
+    x := old[n-1]
+    *h = old[:n-1]
+    return x
+}
+
 type Twitter struct {
     count     int
     tweetMap  map[int][][]int    // userId -> list of [count, tweetId]
@@ -862,9 +876,8 @@ func (this *Twitter) PostTweet(userId int, tweetId int) {
 func (this *Twitter) GetNewsFeed(userId int) []int {
     res := make([]int, 0)
 
-    minHeap := priorityqueue.NewWith(func(a, b interface{}) int {
-        return a.([]int)[0] - b.([]int)[0]
-    })
+    minHeap := &MinHeap{}
+    heap.Init(minHeap)
 
     if this.followMap[userId] == nil {
         this.followMap[userId] = make(map[int]bool)
@@ -876,13 +889,12 @@ func (this *Twitter) GetNewsFeed(userId int) []int {
         if len(tweets) > 0 {
             index := len(tweets) - 1
             count, tweetId := tweets[index][0], tweets[index][1]
-            minHeap.Enqueue([]int{count, tweetId, followeeId, index - 1})
+            heap.Push(minHeap, []int{count, tweetId, followeeId, index - 1})
         }
     }
 
-    for minHeap.Size() > 0 && len(res) < 10 {
-        item, _ := minHeap.Dequeue()
-        curr := item.([]int)
+    for minHeap.Len() > 0 && len(res) < 10 {
+        curr := heap.Pop(minHeap).([]int)
         count, tweetId, followeeId, index := curr[0], curr[1], curr[2], curr[3]
 
         res = append(res, tweetId)
@@ -890,7 +902,7 @@ func (this *Twitter) GetNewsFeed(userId int) []int {
         if index >= 0 {
             tweets := this.tweetMap[followeeId]
             count, tweetId = tweets[index][0], tweets[index][1]
-            minHeap.Enqueue([]int{count, tweetId, followeeId, index - 1})
+            heap.Push(minHeap, []int{count, tweetId, followeeId, index - 1})
         }
     }
 
@@ -1644,6 +1656,21 @@ public class Twitter
 ```
 
 ```go
+// Ordered by the tweet counter at index 0.
+type TweetHeap [][]int
+
+func (h TweetHeap) Len() int            { return len(h) }
+func (h TweetHeap) Less(i, j int) bool  { return h[i][0] < h[j][0] }
+func (h TweetHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *TweetHeap) Push(x interface{}) { *h = append(*h, x.([]int)) }
+func (h *TweetHeap) Pop() interface{} {
+    old := *h
+    n := len(old)
+    x := old[n-1]
+    *h = old[:n-1]
+    return x
+}
+
 type Twitter struct {
     count     int
     tweetMap  map[int][][2]int    // userId -> [count, tweetId]
@@ -1669,63 +1696,38 @@ func (t *Twitter) PostTweet(userId int, tweetId int) {
     t.count--
 }
 
-func maxHeapComparator(a, b interface{}) int {
-    A := a.([]int)
-    B := b.([]int)
-    switch {
-    case A[0] < B[0]:
-        return -1
-    case A[0] > B[0]:
-        return 1
-    default:
-        return 0
-    }
-}
-
-func minHeapComparator(a, b interface{}) int {
-    A := a.([]int)
-    B := b.([]int)
-    switch {
-    case A[0] < B[0]:
-        return -1
-    case A[0] > B[0]:
-        return 1
-    default:
-        return 0
-    }
-}
-
 func (t *Twitter) GetNewsFeed(userId int) []int {
     res := []int{}
     if _, ok := t.followMap[userId]; !ok {
         t.followMap[userId] = make(map[int]bool)
     }
     t.followMap[userId][userId] = true
-    minHeap := priorityqueue.NewWith(minHeapComparator)
+    minHeap := &TweetHeap{}
+    heap.Init(minHeap)
 
     if len(t.followMap[userId]) >= 10 {
-        maxHeap := priorityqueue.NewWith(maxHeapComparator)
+        maxHeap := &TweetHeap{}
+        heap.Init(maxHeap)
         for fId := range t.followMap[userId] {
             if tweets, exists := t.tweetMap[fId]; exists && len(tweets) > 0 {
                 idx := len(tweets) - 1
                 c := tweets[idx][0]
                 tId := tweets[idx][1]
-                maxHeap.Enqueue([]int{-c, tId, fId, idx - 1})
-                if maxHeap.Size() > 10 {
-                    maxHeap.Dequeue()
+                heap.Push(maxHeap, []int{-c, tId, fId, idx - 1})
+                if maxHeap.Len() > 10 {
+                    heap.Pop(maxHeap)
                 }
             }
         }
 
-        for !maxHeap.Empty() {
-            item, _ := maxHeap.Dequeue()
-            arr := item.([]int)
+        for maxHeap.Len() > 0 {
+            arr := heap.Pop(maxHeap).([]int)
             negCount := arr[0]
             tId := arr[1]
             fId := arr[2]
             nextIdx := arr[3]
             realCount := -negCount
-            minHeap.Enqueue([]int{realCount, tId, fId, nextIdx})
+            heap.Push(minHeap, []int{realCount, tId, fId, nextIdx})
         }
     } else {
         for fId := range t.followMap[userId] {
@@ -1733,14 +1735,13 @@ func (t *Twitter) GetNewsFeed(userId int) []int {
                 idx := len(tweets) - 1
                 c := tweets[idx][0]
                 tId := tweets[idx][1]
-                minHeap.Enqueue([]int{c, tId, fId, idx - 1})
+                heap.Push(minHeap, []int{c, tId, fId, idx - 1})
             }
         }
     }
 
-    for !minHeap.Empty() && len(res) < 10 {
-        top, _ := minHeap.Dequeue()
-        arr := top.([]int)
+    for minHeap.Len() > 0 && len(res) < 10 {
+        arr := heap.Pop(minHeap).([]int)
         tId := arr[1]
         fId := arr[2]
         nextIdx := arr[3]
@@ -1748,7 +1749,7 @@ func (t *Twitter) GetNewsFeed(userId int) []int {
         res = append(res, tId)
         if nextIdx >= 0 {
             older := t.tweetMap[fId][nextIdx]
-            minHeap.Enqueue([]int{older[0], older[1], fId, nextIdx - 1})
+            heap.Push(minHeap, []int{older[0], older[1], fId, nextIdx - 1})
         }
     }
 

--- a/articles/find-median-in-a-data-stream.md
+++ b/articles/find-median-in-a-data-stream.md
@@ -494,56 +494,75 @@ public class MedianFinder {
 ```
 
 ```go
+type MaxHeap []int
+
+func (h MaxHeap) Len() int            { return len(h) }
+func (h MaxHeap) Less(i, j int) bool  { return h[i] > h[j] }
+func (h MaxHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MaxHeap) Push(x interface{}) { *h = append(*h, x.(int)) }
+func (h *MaxHeap) Pop() interface{} {
+    old := *h
+    n := len(old)
+    x := old[n-1]
+    *h = old[:n-1]
+    return x
+}
+
+type MinHeap []int
+
+func (h MinHeap) Len() int            { return len(h) }
+func (h MinHeap) Less(i, j int) bool  { return h[i] < h[j] }
+func (h MinHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MinHeap) Push(x interface{}) { *h = append(*h, x.(int)) }
+func (h *MinHeap) Pop() interface{} {
+    old := *h
+    n := len(old)
+    x := old[n-1]
+    *h = old[:n-1]
+    return x
+}
+
 type MedianFinder struct {
-    small *priorityqueue.Queue // maxHeap
-    large *priorityqueue.Queue // minHeap
+    small *MaxHeap // maxHeap
+    large *MinHeap // minHeap
 }
 
 func Constructor() MedianFinder {
-    small := priorityqueue.NewWith(func(a, b interface{}) int {
-        return b.(int) - a.(int)  // maxHeap
-    })
-    large := priorityqueue.NewWith(func(a, b interface{}) int {
-        return a.(int) - b.(int)  // minHeap
-    })
+    small := &MaxHeap{}
+    large := &MinHeap{}
+    heap.Init(small)
+    heap.Init(large)
     return MedianFinder{small: small, large: large}
 }
 
 func (this *MedianFinder) AddNum(num int) {
-    if this.large.Size() > 0 {
-        largeTop, _ := this.large.Peek()
-        if num > largeTop.(int) {
-            this.large.Enqueue(num)
+    if this.large.Len() > 0 {
+        if num > (*this.large)[0] {
+            heap.Push(this.large, num)
         } else {
-            this.small.Enqueue(num)
+            heap.Push(this.small, num)
         }
     } else {
-        this.small.Enqueue(num)
+        heap.Push(this.small, num)
     }
 
     // Rebalance
-    if this.small.Size() > this.large.Size()+1 {
-        val, _ := this.small.Dequeue()
-        this.large.Enqueue(val)
+    if this.small.Len() > this.large.Len()+1 {
+        heap.Push(this.large, heap.Pop(this.small))
     }
-    if this.large.Size() > this.small.Size()+1 {
-        val, _ := this.large.Dequeue()
-        this.small.Enqueue(val)
+    if this.large.Len() > this.small.Len()+1 {
+        heap.Push(this.small, heap.Pop(this.large))
     }
 }
 
 func (this *MedianFinder) FindMedian() float64 {
-    if this.small.Size() > this.large.Size() {
-        val, _ := this.small.Peek()
-        return float64(val.(int))
+    if this.small.Len() > this.large.Len() {
+        return float64((*this.small)[0])
     }
-    if this.large.Size() > this.small.Size() {
-        val, _ := this.large.Peek()
-        return float64(val.(int))
+    if this.large.Len() > this.small.Len() {
+        return float64((*this.large)[0])
     }
-    smallVal, _ := this.small.Peek()
-    largeVal, _ := this.large.Peek()
-    return float64(smallVal.(int)+largeVal.(int)) / 2.0
+    return float64((*this.small)[0]+(*this.large)[0]) / 2.0
 }
 ```
 

--- a/articles/hand-of-straights.md
+++ b/articles/hand-of-straights.md
@@ -495,6 +495,20 @@ public class Solution {
 ```
 
 ```go
+type MinHeap []int
+
+func (h MinHeap) Len() int            { return len(h) }
+func (h MinHeap) Less(i, j int) bool  { return h[i] < h[j] }
+func (h MinHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MinHeap) Push(x interface{}) { *h = append(*h, x.(int)) }
+func (h *MinHeap) Pop() interface{} {
+    old := *h
+    n := len(old)
+    x := old[n-1]
+    *h = old[:n-1]
+    return x
+}
+
 func isNStraightHand(hand []int, groupSize int) bool {
     if len(hand)%groupSize != 0 {
         return false
@@ -505,24 +519,24 @@ func isNStraightHand(hand []int, groupSize int) bool {
         count[n]++
     }
 
-    minH := priorityqueue.NewWith(utils.IntComparator)
+    minH := &MinHeap{}
     for k := range count {
-        minH.Enqueue(k)
+        *minH = append(*minH, k)
     }
+    heap.Init(minH)
 
-    for !minH.Empty() {
-        first, _ := minH.Peek()
-        firstKey := first.(int)
+    for minH.Len() > 0 {
+        firstKey := (*minH)[0]
         for i := firstKey; i < firstKey+groupSize; i++ {
             if count[i] == 0 {
                 return false
             }
             count[i]--
             if count[i] == 0 {
-                if val, _ := minH.Peek(); val.(int) != i {
+                if minH.Len() == 0 || (*minH)[0] != i {
                     return false
                 }
-                minH.Dequeue()
+                heap.Pop(minH)
             }
         }
     }

--- a/articles/invert-a-binary-tree.md
+++ b/articles/invert-a-binary-tree.md
@@ -212,19 +212,18 @@ func invertTree(root *TreeNode) *TreeNode {
     if root == nil {
         return nil
     }
-    queue := arrayqueue.New()
-    queue.Enqueue(root)
+    queue := []*TreeNode{root}
 
-    for queue.Size() > 0 {
-        node, _ := queue.Dequeue()
-        current := node.(*TreeNode)
+    for len(queue) > 0 {
+        current := queue[0]
+        queue = queue[1:]
         current.Left, current.Right = current.Right, current.Left
 
         if current.Left != nil {
-            queue.Enqueue(current.Left)
+            queue = append(queue, current.Left)
         }
         if current.Right != nil {
-            queue.Enqueue(current.Right)
+            queue = append(queue, current.Right)
         }
     }
     return root

--- a/articles/k-closest-points-to-origin.md
+++ b/articles/k-closest-points-to-origin.md
@@ -272,23 +272,33 @@ public class Solution {
 ```
 
 ```go
+type MinHeap [][]int
+
+func (h MinHeap) Len() int            { return len(h) }
+func (h MinHeap) Less(i, j int) bool  { return h[i][0] < h[j][0] }
+func (h MinHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MinHeap) Push(x interface{}) { *h = append(*h, x.([]int)) }
+func (h *MinHeap) Pop() interface{} {
+    old := *h
+    n := len(old)
+    x := old[n-1]
+    *h = old[:n-1]
+    return x
+}
+
 func kClosest(points [][]int, k int) [][]int {
-    minHeap := priorityqueue.NewWith(func(a, b interface{}) int {
-        distA := a.([]int)[0]
-        distB := b.([]int)[0]
-        return distA - distB
-    })
+    minHeap := &MinHeap{}
+    heap.Init(minHeap)
 
     for _, point := range points {
         x, y := point[0], point[1]
         dist := x*x + y*y
-        minHeap.Enqueue([]int{dist, x, y})
+        heap.Push(minHeap, []int{dist, x, y})
     }
 
     res := [][]int{}
     for i := 0; i < k; i++ {
-        item, _ := minHeap.Dequeue()
-        point := item.([]int)
+        point := heap.Pop(minHeap).([]int)
         res = append(res, []int{point[1], point[2]})
     }
 
@@ -528,31 +538,36 @@ public class Solution {
 ```
 
 ```go
+type MaxHeap [][]int
+
+func (h MaxHeap) Len() int            { return len(h) }
+func (h MaxHeap) Less(i, j int) bool  { return h[i][2] > h[j][2] }
+func (h MaxHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MaxHeap) Push(x interface{}) { *h = append(*h, x.([]int)) }
+func (h *MaxHeap) Pop() interface{} {
+    old := *h
+    n := len(old)
+    x := old[n-1]
+    *h = old[:n-1]
+    return x
+}
+
 func kClosest(points [][]int, k int) [][]int {
-    maxHeap := priorityqueue.NewWith(func(a, b interface{}) int {
-        distA := a.([]int)[2]
-        distB := b.([]int)[2]
-        if distA > distB {
-            return -1
-        } else if distA < distB {
-            return 1
-        }
-        return 0
-    })
+    maxHeap := &MaxHeap{}
+    heap.Init(maxHeap)
 
     for _, point := range points {
         x, y := point[0], point[1]
         dist := x*x + y*y
-        maxHeap.Enqueue([]int{x, y, dist})
-        if maxHeap.Size() > k {
-            maxHeap.Dequeue()
+        heap.Push(maxHeap, []int{x, y, dist})
+        if maxHeap.Len() > k {
+            heap.Pop(maxHeap)
         }
     }
 
     result := make([][]int, k)
     for i := k - 1; i >= 0; i-- {
-        val, _ := maxHeap.Dequeue()
-        point := val.([]int)
+        point := heap.Pop(maxHeap).([]int)
         result[i] = []int{point[0], point[1]}
     }
 

--- a/articles/kth-largest-element-in-an-array.md
+++ b/articles/kth-largest-element-in-an-array.md
@@ -230,18 +230,32 @@ public class Solution {
 ```
 
 ```go
+type MinHeap []int
+
+func (h MinHeap) Len() int            { return len(h) }
+func (h MinHeap) Less(i, j int) bool  { return h[i] < h[j] }
+func (h MinHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MinHeap) Push(x interface{}) { *h = append(*h, x.(int)) }
+func (h *MinHeap) Pop() interface{} {
+    old := *h
+    n := len(old)
+    x := old[n-1]
+    *h = old[:n-1]
+    return x
+}
+
 func findKthLargest(nums []int, k int) int {
-    minHeap := priorityqueue.NewWith(utils.IntComparator)
+    minHeap := &MinHeap{}
+    heap.Init(minHeap)
 
     for _, num := range nums {
-        minHeap.Enqueue(num)
-        if minHeap.Size() > k {
-            minHeap.Dequeue()
+        heap.Push(minHeap, num)
+        if minHeap.Len() > k {
+            heap.Pop(minHeap)
         }
     }
 
-    val, _ := minHeap.Peek()
-    return val.(int)
+    return (*minHeap)[0]
 }
 ```
 

--- a/articles/kth-largest-integer-in-a-stream.md
+++ b/articles/kth-largest-integer-in-a-stream.md
@@ -376,29 +376,43 @@ public class KthLargest {
 ```
 
 ```go
+type MinHeap []int
+
+func (h MinHeap) Len() int            { return len(h) }
+func (h MinHeap) Less(i, j int) bool  { return h[i] < h[j] }
+func (h MinHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MinHeap) Push(x interface{}) { *h = append(*h, x.(int)) }
+func (h *MinHeap) Pop() interface{} {
+    old := *h
+    n := len(old)
+    x := old[n-1]
+    *h = old[:n-1]
+    return x
+}
+
 type KthLargest struct {
-    minHeap *priorityqueue.Queue
+    minHeap *MinHeap
     k       int
 }
 
 func Constructor(k int, nums []int) KthLargest {
-    minHeap := priorityqueue.NewWith(utils.IntComparator)
+    minHeap := &MinHeap{}
+    heap.Init(minHeap)
     for _, num := range nums {
-        minHeap.Enqueue(num)
+        heap.Push(minHeap, num)
     }
-    for minHeap.Size() > k {
-        minHeap.Dequeue()
+    for minHeap.Len() > k {
+        heap.Pop(minHeap)
     }
     return KthLargest{minHeap: minHeap, k: k}
 }
 
 func (this *KthLargest) Add(val int) int {
-    this.minHeap.Enqueue(val)
-    if this.minHeap.Size() > this.k {
-        this.minHeap.Dequeue()
+    heap.Push(this.minHeap, val)
+    if this.minHeap.Len() > this.k {
+        heap.Pop(this.minHeap)
     }
-    top, _ := this.minHeap.Peek()
-    return top.(int)
+    return (*this.minHeap)[0]
 }
 ```
 

--- a/articles/kth-smallest-integer-in-bst.md
+++ b/articles/kth-smallest-integer-in-bst.md
@@ -216,12 +216,13 @@ func kthSmallest(root *TreeNode, k int) int {
             return
         }
 
-        dfs(node.Left)
         arr = append(arr, node.Val)
+        dfs(node.Left)
         dfs(node.Right)
     }
 
     dfs(root)
+    sort.Ints(arr)
     return arr[k-1]
 }
 ```
@@ -242,6 +243,7 @@ class Solution {
 
     fun kthSmallest(root: TreeNode?, k: Int): Int {
         dfs(root)
+        arr.sort()
         return arr[k - 1]
     }
 
@@ -250,8 +252,8 @@ class Solution {
             return
         }
 
-        dfs(node.left)
         arr.add(node.`val`)
+        dfs(node.left)
         dfs(node.right)
     }
 }
@@ -1674,33 +1676,34 @@ func kthSmallest(root *TreeNode, k int) int {
  */
 class Solution {
     fun kthSmallest(root: TreeNode?, k: Int): Int {
-        var curr: TreeNode? = root
+        var curr = root
         var k = k
-        while (true) {
-            if (curr?.left == null) {
+        while (curr != null) {
+            if (curr.left == null) {
                 k--
                 if (k == 0) {
-                    return curr!!.`val`
+                    return curr.`val`
                 }
-                curr = curr?.right
+                curr = curr.right
             } else {
-                var pred = curr.left
-                while (pred?.right != null && pred.right != curr) {
-                    pred = pred.right
+                var pred = curr.left!!
+                while (pred.right != null && pred.right != curr) {
+                    pred = pred.right!!
                 }
-                if (pred?.right == null) {
+                if (pred.right == null) {
                     pred.right = curr
                     curr = curr.left
                 } else {
                     pred.right = null
                     k--
                     if (k == 0) {
-                        return curr!!.`val`
+                        return curr.`val`
                     }
                     curr = curr.right
                 }
             }
         }
+        return -1
     }
 }
 ```

--- a/articles/last-stone-weight.md
+++ b/articles/last-stone-weight.md
@@ -708,26 +708,38 @@ public class Solution {
 ```
 
 ```go
+type MinHeap []int
+
+func (h MinHeap) Len() int            { return len(h) }
+func (h MinHeap) Less(i, j int) bool  { return h[i] < h[j] }
+func (h MinHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MinHeap) Push(x interface{}) { *h = append(*h, x.(int)) }
+func (h *MinHeap) Pop() interface{} {
+    old := *h
+    n := len(old)
+    x := old[n-1]
+    *h = old[:n-1]
+    return x
+}
+
 func lastStoneWeight(stones []int) int {
-    pq := priorityqueue.NewWith(func(a, b interface{}) int {
-        return a.(int) - b.(int)
-    })
+    pq := &MinHeap{}
+    heap.Init(pq)
 
     for _, s := range stones {
-        pq.Enqueue(-s)
+        heap.Push(pq, -s)
     }
 
-    for pq.Size() > 1 {
-        first, _ := pq.Dequeue()
-        second, _ := pq.Dequeue()
-        if second.(int) > first.(int) {
-            pq.Enqueue(first.(int) - second.(int))
+    for pq.Len() > 1 {
+        first := heap.Pop(pq).(int)
+        second := heap.Pop(pq).(int)
+        if second > first {
+            heap.Push(pq, first-second)
         }
     }
 
-    pq.Enqueue(0)
-    result, _ := pq.Dequeue()
-    return -result.(int)
+    heap.Push(pq, 0)
+    return -heap.Pop(pq).(int)
 }
 ```
 

--- a/articles/longest-continuous-subarray-with-absolute-diff-less-than-or-equal-to-limit.md
+++ b/articles/longest-continuous-subarray-with-absolute-diff-less-than-or-equal-to-limit.md
@@ -712,31 +712,37 @@ public class Solution {
 
 ```go
 func longestSubarray(nums []int, limit int) int {
-    tree := redblacktree.NewWithIntComparator()
-    l, res := 0, 0
+    // Go has no ordered map in its standard library, so the sorted dict is
+    // modeled with a count map plus a slice of the distinct values in the
+    // window kept in ascending order (binary searched with sort.SearchInts).
+    counts := make(map[int]int)
+    keys := []int{}
 
-    for r := 0; r < len(nums); r++ {
-        x := nums[r]
-        if val, found := tree.Get(x); found {
-            tree.Put(x, val.(int)+1)
-        } else {
-            tree.Put(x, 1)
+    put := func(x int) {
+        counts[x]++
+        if counts[x] == 1 {
+            i := sort.SearchInts(keys, x)
+            keys = append(keys, 0)
+            copy(keys[i+1:], keys[i:])
+            keys[i] = x
         }
+    }
+    remove := func(x int) {
+        counts[x]--
+        if counts[x] == 0 {
+            delete(counts, x)
+            i := sort.SearchInts(keys, x)
+            keys = append(keys[:i], keys[i+1:]...)
+        }
+    }
 
-        for tree.Size() > 0 {
-            maxKey := tree.Right().Key.(int)
-            minKey := tree.Left().Key.(int)
-            if maxKey-minKey <= limit {
-                break
-            }
-            y := nums[l]
+    l, res := 0, 0
+    for r := 0; r < len(nums); r++ {
+        put(nums[r])
+
+        for len(keys) > 0 && keys[len(keys)-1]-keys[0] > limit {
+            remove(nums[l])
             l++
-            val, _ := tree.Get(y)
-            if val.(int) == 1 {
-                tree.Remove(y)
-            } else {
-                tree.Put(y, val.(int)-1)
-            }
         }
 
         if r-l+1 > res {

--- a/articles/longest-substring-without-duplicates.md
+++ b/articles/longest-substring-without-duplicates.md
@@ -165,7 +165,7 @@ class Solution {
 }
 ```
 
-```kotlin
+```swift
 class Solution {
     func lengthOfLongestSubstring(_ s: String) -> Int {
         var res = 0

--- a/articles/meeting-schedule-ii.md
+++ b/articles/meeting-schedule-ii.md
@@ -196,23 +196,36 @@ public class Solution {
  * }
  */
 
+type MinHeap []int
+
+func (h MinHeap) Len() int            { return len(h) }
+func (h MinHeap) Less(i, j int) bool  { return h[i] < h[j] }
+func (h MinHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MinHeap) Push(x interface{}) { *h = append(*h, x.(int)) }
+func (h *MinHeap) Pop() interface{} {
+    old := *h
+    n := len(old)
+    x := old[n-1]
+    *h = old[:n-1]
+    return x
+}
+
 func minMeetingRooms(intervals []Interval) int {
     sort.Slice(intervals, func(i, j int) bool {
         return intervals[i].start < intervals[j].start
     })
 
-    pq := priorityqueue.NewWith(utils.IntComparator)
+    pq := &MinHeap{}
+    heap.Init(pq)
 
     for _, interval := range intervals {
-        if pq.Size() > 0 {
-            if top, _ := pq.Peek(); top.(int) <= interval.start {
-                pq.Dequeue()
-            }
+        if pq.Len() > 0 && (*pq)[0] <= interval.start {
+            heap.Pop(pq)
         }
-        pq.Enqueue(interval.end)
+        heap.Push(pq, interval.end)
     }
 
-    return pq.Size()
+    return pq.Len()
 }
 ```
 

--- a/articles/merge-k-sorted-linked-lists.md
+++ b/articles/merge-k-sorted-linked-lists.md
@@ -1441,31 +1441,44 @@ public class Solution {
  *     Next *ListNode
  * }
  */
+type NodeHeap []*ListNode
+
+func (h NodeHeap) Len() int            { return len(h) }
+func (h NodeHeap) Less(i, j int) bool  { return h[i].Val < h[j].Val }
+func (h NodeHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *NodeHeap) Push(x interface{}) { *h = append(*h, x.(*ListNode)) }
+func (h *NodeHeap) Pop() interface{} {
+    old := *h
+    n := len(old)
+    x := old[n-1]
+    *h = old[:n-1]
+    return x
+}
+
 func mergeKLists(lists []*ListNode) *ListNode {
     if len(lists) == 0 {
         return nil
     }
 
-    minHeap := priorityqueue.NewWith(func(a, b interface{}) int {
-        return a.(*ListNode).Val - b.(*ListNode).Val
-    })
+    minHeap := &NodeHeap{}
+    heap.Init(minHeap)
 
     for _, list := range lists {
         if list != nil {
-            minHeap.Enqueue(list)
+            heap.Push(minHeap, list)
         }
     }
 
     res := &ListNode{Val: 0}
     cur := res
 
-    for !minHeap.Empty() {
-        node, _ := minHeap.Dequeue()
-        cur.Next = node.(*ListNode)
+    for minHeap.Len() > 0 {
+        node := heap.Pop(minHeap).(*ListNode)
+        cur.Next = node
         cur = cur.Next
 
         if cur.Next != nil {
-            minHeap.Enqueue(cur.Next)
+            heap.Push(minHeap, cur.Next)
         }
     }
 

--- a/articles/min-cost-to-connect-points.md
+++ b/articles/min-cost-to-connect-points.md
@@ -822,6 +822,20 @@ public class Solution {
 ```
 
 ```go
+type MinHeap [][]int
+
+func (h MinHeap) Len() int            { return len(h) }
+func (h MinHeap) Less(i, j int) bool  { return h[i][0] < h[j][0] }
+func (h MinHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MinHeap) Push(x interface{}) { *h = append(*h, x.([]int)) }
+func (h *MinHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
 func minCostConnectPoints(points [][]int) int {
 	n := len(points)
 	adj := make(map[int][][]int)
@@ -837,17 +851,16 @@ func minCostConnectPoints(points [][]int) int {
 
 	res := 0
 	visit := make(map[int]bool)
-	pq := priorityqueue.NewWith(func(a, b interface{}) int {
-		return utils.IntComparator(a.([]int)[0], b.([]int)[0])
-	})
-	pq.Enqueue([]int{0, 0})
+	pq := &MinHeap{}
+	heap.Init(pq)
+	heap.Push(pq, []int{0, 0})
 
 	for len(visit) < n {
-		item, ok := pq.Dequeue()
-		if !ok {
-			continue
+		if pq.Len() == 0 {
+			break
 		}
-		cost, point := item.([]int)[0], item.([]int)[1]
+		item := heap.Pop(pq).([]int)
+		cost, point := item[0], item[1]
 		if visit[point] {
 			continue
 		}
@@ -857,7 +870,7 @@ func minCostConnectPoints(points [][]int) int {
 		for _, edge := range adj[point] {
 			neiCost, neiPoint := edge[0], edge[1]
 			if !visit[neiPoint] {
-				pq.Enqueue([]int{neiCost, neiPoint})
+				heap.Push(pq, []int{neiCost, neiPoint})
 			}
 		}
 	}

--- a/articles/minimum-interval-including-query.md
+++ b/articles/minimum-interval-including-query.md
@@ -525,6 +525,20 @@ type Event struct {
 	idx  int // interval index
 }
 
+type MinHeap [][]int
+
+func (h MinHeap) Len() int            { return len(h) }
+func (h MinHeap) Less(i, j int) bool  { return h[i][0] < h[j][0] }
+func (h MinHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MinHeap) Push(x interface{}) { *h = append(*h, x.([]int)) }
+func (h *MinHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
 func minInterval(intervals [][]int, queries []int) []int {
 	events := []Event{}
 
@@ -550,9 +564,8 @@ func minInterval(intervals [][]int, queries []int) []int {
 	})
 
 	// Priority queue to store intervals with the smallest size on top
-	sizes := priorityqueue.NewWith(func(a, b interface{}) int {
-		return utils.IntComparator(a.([]int)[0], b.([]int)[0])
-	})
+	sizes := &MinHeap{}
+	heap.Init(sizes)
 	ans := make([]int, len(queries))
 	for i := range ans {
 		ans[i] = -1
@@ -562,22 +575,16 @@ func minInterval(intervals [][]int, queries []int) []int {
 	for _, event := range events {
 		switch event.typ {
 		case 0: // Interval start
-			sizes.Enqueue([]int{event.val, event.idx})
+			heap.Push(sizes, []int{event.val, event.idx})
 		case 2: // Interval end
 			inactive[event.idx] = true
 		case 1: // Query
 			queryIdx := event.val
-			for !sizes.Empty() {
-				top, _ := sizes.Peek()
-				if inactive[top.([]int)[1]] {
-					sizes.Dequeue()
-				} else {
-					break
-				}
+			for sizes.Len() > 0 && inactive[(*sizes)[0][1]] {
+				heap.Pop(sizes)
 			}
-			if !sizes.Empty() {
-				top, _ := sizes.Peek()
-				ans[queryIdx] = top.([]int)[0]
+			if sizes.Len() > 0 {
+				ans[queryIdx] = (*sizes)[0][0]
 			}
 		}
 	}
@@ -971,6 +978,20 @@ public class Solution {
 ```
 
 ```go
+type MinHeap [][2]int
+
+func (h MinHeap) Len() int            { return len(h) }
+func (h MinHeap) Less(i, j int) bool  { return h[i][0] < h[j][0] }
+func (h MinHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MinHeap) Push(x interface{}) { *h = append(*h, x.([2]int)) }
+func (h *MinHeap) Pop() interface{} {
+    old := *h
+    n := len(old)
+    x := old[n-1]
+    *h = old[:n-1]
+    return x
+}
+
 func minInterval(intervals [][]int, queries []int) []int {
     sort.Slice(intervals, func(i, j int) bool {
         return intervals[i][0] < intervals[j][0]
@@ -984,19 +1005,8 @@ func minInterval(intervals [][]int, queries []int) []int {
         return queriesWithIdx[i][0] < queriesWithIdx[j][0]
     })
 
-    comparator := func(a, b interface{}) int {
-        pair1 := a.([2]int)
-        pair2 := b.([2]int)
-        if pair1[0] != pair2[0] {
-            if pair1[0] < pair2[0] {
-                return -1
-            }
-            return 1
-        }
-        return 0
-    }
-
-    pq := priorityqueue.NewWith(comparator)
+    pq := &MinHeap{}
+    heap.Init(pq)
     res := make([]int, len(queries))
     i := 0
 
@@ -1005,22 +1015,16 @@ func minInterval(intervals [][]int, queries []int) []int {
 
         for i < len(intervals) && intervals[i][0] <= q {
             size := intervals[i][1] - intervals[i][0] + 1
-            pq.Enqueue([2]int{size, intervals[i][1]})
+            heap.Push(pq, [2]int{size, intervals[i][1]})
             i++
         }
 
-        for !pq.Empty() {
-            if top, _ := pq.Peek(); top.([2]int)[1] < q {
-                pq.Dequeue()
-            } else {
-                break
-            }
+        for pq.Len() > 0 && (*pq)[0][1] < q {
+            heap.Pop(pq)
         }
 
-        if !pq.Empty() {
-            if top, _ := pq.Peek(); true {
-                res[originalIdx] = top.([2]int)[0]
-            }
+        if pq.Len() > 0 {
+            res[originalIdx] = (*pq)[0][0]
         } else {
             res[originalIdx] = -1
         }

--- a/articles/minimum-stack.md
+++ b/articles/minimum-stack.md
@@ -225,39 +225,40 @@ public class MinStack {
 
 ```go
 type MinStack struct {
-    stack *linkedliststack.Stack
+    stack []int
 }
 
 func Constructor() MinStack {
-    return MinStack{stack: linkedliststack.New()}
+    return MinStack{stack: []int{}}
 }
 
 func (this *MinStack) Push(val int) {
-    this.stack.Push(val)
+    this.stack = append(this.stack, val)
 }
 
 func (this *MinStack) Pop() {
-    this.stack.Pop()
+    this.stack = this.stack[:len(this.stack)-1]
 }
 
 func (this *MinStack) Top() int {
-    top, _ := this.stack.Peek()
-    return top.(int)
+    return this.stack[len(this.stack)-1]
 }
 
 func (this *MinStack) GetMin() int {
-    tmp := linkedliststack.New()
+    tmp := []int{}
     min := this.Top()
 
-    for !this.stack.Empty() {
-        val, _ := this.stack.Pop()
-        min = getMin(min, val.(int))
-        tmp.Push(val)
+    for len(this.stack) > 0 {
+        val := this.stack[len(this.stack)-1]
+        this.stack = this.stack[:len(this.stack)-1]
+        min = getMin(min, val)
+        tmp = append(tmp, val)
     }
 
-    for !tmp.Empty() {
-        val, _ := tmp.Pop()
-        this.stack.Push(val)
+    for len(tmp) > 0 {
+        val := tmp[len(tmp)-1]
+        tmp = tmp[:len(tmp)-1]
+        this.stack = append(this.stack, val)
     }
 
     return min
@@ -583,43 +584,39 @@ public class MinStack {
 
 ```go
 type MinStack struct {
-    stack    *linkedliststack.Stack
-    minStack *linkedliststack.Stack
+    stack    []int
+    minStack []int
 }
 
 func Constructor() MinStack {
     return MinStack{
-        stack:    linkedliststack.New(),
-        minStack: linkedliststack.New(),
+        stack:    []int{},
+        minStack: []int{},
     }
 }
 
 func (this *MinStack) Push(val int) {
-    this.stack.Push(val)
+    this.stack = append(this.stack, val)
     minVal := val
-    if !this.minStack.Empty() {
-        if top, ok := this.minStack.Peek(); ok {
-            if top.(int) < val {
-                minVal = top.(int)
-            }
+    if len(this.minStack) > 0 {
+        if top := this.minStack[len(this.minStack)-1]; top < val {
+            minVal = top
         }
     }
-    this.minStack.Push(minVal)
+    this.minStack = append(this.minStack, minVal)
 }
 
 func (this *MinStack) Pop() {
-    this.stack.Pop()
-    this.minStack.Pop()
+    this.stack = this.stack[:len(this.stack)-1]
+    this.minStack = this.minStack[:len(this.minStack)-1]
 }
 
 func (this *MinStack) Top() int {
-    top, _ := this.stack.Peek()
-    return top.(int)
+    return this.stack[len(this.stack)-1]
 }
 
 func (this *MinStack) GetMin() int {
-    min, _ := this.minStack.Peek()
-    return min.(int)
+    return this.minStack[len(this.minStack)-1]
 }
 ```
 

--- a/articles/network-delay-time.md
+++ b/articles/network-delay-time.md
@@ -1487,6 +1487,20 @@ type Edge struct {
     node, weight int
 }
 
+type MinHeap []Edge
+
+func (h MinHeap) Len() int            { return len(h) }
+func (h MinHeap) Less(i, j int) bool  { return h[i].weight < h[j].weight }
+func (h MinHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MinHeap) Push(x interface{}) { *h = append(*h, x.(Edge)) }
+func (h *MinHeap) Pop() interface{} {
+    old := *h
+    n := len(old)
+    x := old[n-1]
+    *h = old[:n-1]
+    return x
+}
+
 func networkDelayTime(times [][]int, n int, k int) int {
     edges := make(map[int][]Edge)
     for _, time := range times {
@@ -1494,17 +1508,15 @@ func networkDelayTime(times [][]int, n int, k int) int {
         edges[u] = append(edges[u], Edge{node: v, weight: w})
     }
 
-    pq := priorityqueue.NewWith(func(a, b interface{}) int {
-        return utils.IntComparator(a.(Edge).weight, b.(Edge).weight)
-    })
-    pq.Enqueue(Edge{node: k, weight: 0})
+    pq := &MinHeap{}
+    heap.Init(pq)
+    heap.Push(pq, Edge{node: k, weight: 0})
 
     visited := make(map[int]bool)
     t := 0
 
-    for !pq.Empty() {
-        item, _ := pq.Dequeue()
-        edge := item.(Edge)
+    for pq.Len() > 0 {
+        edge := heap.Pop(pq).(Edge)
         node, time := edge.node, edge.weight
 
         if visited[node] {
@@ -1515,7 +1527,7 @@ func networkDelayTime(times [][]int, n int, k int) int {
 
         for _, next := range edges[node] {
             if !visited[next.node] {
-                pq.Enqueue(Edge{node: next.node, weight: time + next.weight})
+                heap.Push(pq, Edge{node: next.node, weight: time + next.weight})
             }
         }
     }

--- a/articles/palindrome-partitioning.md
+++ b/articles/palindrome-partitioning.md
@@ -1153,8 +1153,8 @@ impl Solution {
         let mut dp = vec![vec![false; n]; n];
         for l in 1..=n {
             for i in 0..=n - l {
-                dp[i][i + l - 1] = s[i] == s[i + l - 1]
-                    && (i + 1 > i + l - 2 || dp[i + 1][i + l - 2]);
+                let j = i + l - 1;
+                dp[i][j] = s[i] == s[j] && (l <= 2 || dp[i + 1][j - 1]);
             }
         }
 
@@ -1541,8 +1541,8 @@ impl Solution {
         let mut dp = vec![vec![false; n]; n];
         for l in 1..=n {
             for i in 0..=n - l {
-                dp[i][i + l - 1] = s[i] == s[i + l - 1]
-                    && (i + 1 > i + l - 2 || dp[i + 1][i + l - 2]);
+                let j = i + l - 1;
+                dp[i][j] = s[i] == s[j] && (l <= 2 || dp[i + 1][j - 1]);
             }
         }
 

--- a/articles/pow-x-n.md
+++ b/articles/pow-x-n.md
@@ -618,11 +618,11 @@ class Solution {
         let power = Math.abs(n);
 
         while (power > 0) {
-            if (power & 1) {
+            if (power % 2 === 1) {
                 res *= x;
             }
             x *= x;
-            power >>= 1;
+            power = Math.floor(power / 2);
         }
 
         return n >= 0 ? res : 1 / res;
@@ -772,6 +772,8 @@ impl Solution {
 ### Integer Overflow When Negating n
 
 When `n` is `Integer.MIN_VALUE` (-2147483648), computing `abs(n)` or `-n` overflows because the positive equivalent exceeds `Integer.MAX_VALUE`. Always cast to a `long` before taking the absolute value to avoid this undefined behavior.
+
+In JavaScript, `Math.abs(n)` is safe on its own (numbers are doubles), but the bitwise operators are not: `power & 1` and `power >>= 1` first convert `power` to a signed 32-bit integer, so `2147483648` becomes `-2147483648` and the loop terminates immediately. Use `power % 2` and `Math.floor(power / 2)` instead of bitwise operations.
 
 ### Forgetting to Handle Negative Exponents
 

--- a/articles/sliding-window-maximum.md
+++ b/articles/sliding-window-maximum.md
@@ -905,22 +905,32 @@ public class Solution {
 ```
 
 ```go
+type MaxHeap [][2]int
+
+func (h MaxHeap) Len() int            { return len(h) }
+func (h MaxHeap) Less(i, j int) bool  { return h[i][0] > h[j][0] }
+func (h MaxHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MaxHeap) Push(x interface{}) { *h = append(*h, x.([2]int)) }
+func (h *MaxHeap) Pop() interface{} {
+   old := *h
+   n := len(old)
+   x := old[n-1]
+   *h = old[:n-1]
+   return x
+}
+
 func maxSlidingWindow(nums []int, k int) []int {
-   heap := priorityqueue.NewWith(func(a, b interface{}) int {
-       return b.([2]int)[0] - a.([2]int)[0]
-   })
+   maxHeap := &MaxHeap{}
+   heap.Init(maxHeap)
 
    output := []int{}
    for i := 0; i < len(nums); i++ {
-       heap.Enqueue([2]int{nums[i], i})
+       heap.Push(maxHeap, [2]int{nums[i], i})
        if i >= k - 1 {
-           peek, _ := heap.Peek()
-           for peek.([2]int)[1] <= i - k {
-               heap.Dequeue()
-               peek, _ = heap.Peek()
+           for (*maxHeap)[0][1] <= i - k {
+               heap.Pop(maxHeap)
            }
-           val, _ := heap.Peek()
-           output = append(output, val.([2]int)[0])
+           output = append(output, (*maxHeap)[0][0])
        }
    }
    return output

--- a/articles/swim-in-rising-water.md
+++ b/articles/swim-in-rising-water.md
@@ -1473,21 +1473,33 @@ type Node struct {
     time, r, c int
 }
 
+type MinHeap []Node
+
+func (h MinHeap) Len() int            { return len(h) }
+func (h MinHeap) Less(i, j int) bool  { return h[i].time < h[j].time }
+func (h MinHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MinHeap) Push(x interface{}) { *h = append(*h, x.(Node)) }
+func (h *MinHeap) Pop() interface{} {
+    old := *h
+    n := len(old)
+    x := old[n-1]
+    *h = old[:n-1]
+    return x
+}
+
 func swimInWater(grid [][]int) int {
     N := len(grid)
     directions := [][2]int{{0, 1}, {0, -1}, {1, 0}, {-1, 0}}
 
-    pq := priorityqueue.NewWith(func(a, b interface{}) int {
-        return utils.IntComparator(a.(Node).time, b.(Node).time)
-    })
+    pq := &MinHeap{}
+    heap.Init(pq)
 
-    pq.Enqueue(Node{grid[0][0], 0, 0})
+    heap.Push(pq, Node{grid[0][0], 0, 0})
     visited := make(map[[2]int]bool)
     visited[[2]int{0, 0}] = true
 
-    for !pq.Empty() {
-        item, _ := pq.Dequeue()
-        node := item.(Node)
+    for pq.Len() > 0 {
+        node := heap.Pop(pq).(Node)
         t, r, c := node.time, node.r, node.c
 
         if r == N-1 && c == N-1 {
@@ -1502,7 +1514,7 @@ func swimInWater(grid [][]int) int {
             }
 
             visited[[2]int{neiR, neiC}] = true
-            pq.Enqueue(Node{max(t, grid[neiR][neiC]), neiR, neiC})
+            heap.Push(pq, Node{max(t, grid[neiR][neiC]), neiR, neiC})
         }
     }
 

--- a/articles/task-scheduling.md
+++ b/articles/task-scheduling.md
@@ -705,37 +705,49 @@ public class Solution {
 ```
 
 ```go
+type MaxHeap []int
+
+func (h MaxHeap) Len() int            { return len(h) }
+func (h MaxHeap) Less(i, j int) bool  { return h[i] > h[j] }
+func (h MaxHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MaxHeap) Push(x interface{}) { *h = append(*h, x.(int)) }
+func (h *MaxHeap) Pop() interface{} {
+    old := *h
+    n := len(old)
+    x := old[n-1]
+    *h = old[:n-1]
+    return x
+}
+
 func leastInterval(tasks []byte, n int) int {
     count := make(map[byte]int)
     for _, task := range tasks {
         count[task]++
     }
 
-    maxHeap := priorityqueue.NewWith(func(a, b interface{}) int {
-        return b.(int) - a.(int)
-    })
+    maxHeap := &MaxHeap{}
     for _, cnt := range count {
-        maxHeap.Enqueue(cnt)
+        *maxHeap = append(*maxHeap, cnt)
     }
+    heap.Init(maxHeap)
 
     time := 0
     q := make([][2]int, 0)
 
-    for maxHeap.Size() > 0 || len(q) > 0 {
+    for maxHeap.Len() > 0 || len(q) > 0 {
         time++
 
-        if maxHeap.Size() == 0 {
+        if maxHeap.Len() == 0 {
             time = q[0][1]
         } else {
-            cnt, _ := maxHeap.Dequeue()
-            cnt = cnt.(int) - 1
-            if cnt.(int) > 0 {
-                q = append(q, [2]int{cnt.(int), time + n})
+            cnt := heap.Pop(maxHeap).(int) - 1
+            if cnt > 0 {
+                q = append(q, [2]int{cnt, time + n})
             }
         }
 
         if len(q) > 0 && q[0][1] == time {
-            maxHeap.Enqueue(q[0][0])
+            heap.Push(maxHeap, q[0][0])
             q = q[1:]
         }
     }

--- a/articles/time-based-key-value-store.md
+++ b/articles/time-based-key-value-store.md
@@ -48,12 +48,12 @@ class TimeMap:
     def get(self, key: str, timestamp: int) -> str:
         if key not in self.keyStore:
             return ""
-        seen = 0
+        seen = -1
 
         for time in self.keyStore[key]:
             if time <= timestamp:
                 seen = max(seen, time)
-        return "" if seen == 0 else self.keyStore[key][seen][-1]
+        return "" if seen == -1 else self.keyStore[key][seen][-1]
 ```
 
 ```java
@@ -78,14 +78,14 @@ public class TimeMap {
         if (!keyStore.containsKey(key)) {
             return "";
         }
-        int seen = 0;
+        int seen = -1;
 
         for (int time : keyStore.get(key).keySet()) {
             if (time <= timestamp) {
                 seen = Math.max(seen, time);
             }
         }
-        if (seen == 0) return "";
+        if (seen == -1) return "";
         int back = keyStore.get(key).get(seen).size() - 1;
         return keyStore.get(key).get(seen).get(back);
     }
@@ -106,13 +106,13 @@ public:
         if (keyStore.find(key) == keyStore.end()) {
             return "";
         }
-        int seen = 0;
+        int seen = -1;
         for (const auto& [time, _] : keyStore[key]) {
             if (time <= timestamp) {
                 seen = max(seen, time);
             }
         }
-        return seen == 0 ? "" : keyStore[key][seen].back();
+        return seen == -1 ? "" : keyStore[key][seen].back();
     }
 };
 ```
@@ -148,14 +148,14 @@ class TimeMap {
         if (!this.keyStore.has(key)) {
             return '';
         }
-        let seen = 0;
+        let seen = -1;
 
         for (let time of this.keyStore.get(key).keys()) {
             if (time <= timestamp) {
                 seen = Math.max(seen, time);
             }
         }
-        return seen === 0 ? '' : this.keyStore.get(key).get(seen).at(-1);
+        return seen === -1 ? '' : this.keyStore.get(key).get(seen).at(-1);
     }
 }
 ```
@@ -183,14 +183,14 @@ public class TimeMap {
             return "";
         }
         var timestamps = keyStore[key];
-        int seen = 0;
+        int seen = -1;
 
         foreach (var time in timestamps.Keys) {
             if (time <= timestamp) {
-                seen = time;
+                seen = Math.Max(seen, time);
             }
         }
-        return seen == 0 ? "" : timestamps[seen][^1];
+        return seen == -1 ? "" : timestamps[seen][^1];
     }
 }
 ```
@@ -218,14 +218,14 @@ func (this *TimeMap) Get(key string, timestamp int) string {
        return ""
    }
 
-   seen := 0
+   seen := -1
    for time := range this.keyStore[key] {
        if time <= timestamp {
            seen = max(seen, time)
        }
    }
 
-   if seen == 0 {
+   if seen == -1 {
        return ""
    }
    values := this.keyStore[key][seen]
@@ -259,14 +259,14 @@ class TimeMap() {
             return ""
         }
 
-        var seen = 0
+        var seen = -1
         for (time in keyStore[key]!!.keys) {
             if (time <= timestamp) {
                 seen = maxOf(seen, time)
             }
         }
 
-        if (seen == 0) {
+        if (seen == -1) {
             return ""
         }
         return keyStore[key]!![seen]!!.last()
@@ -297,13 +297,13 @@ class TimeMap {
             return ""
         }
 
-        var seen = 0
+        var seen = -1
         for time in timeMap.keys {
             if time <= timestamp {
                 seen = max(seen, time)
             }
         }
-        return seen == 0 ? "" : timeMap[seen]!.last!
+        return seen == -1 ? "" : timeMap[seen]!.last!
     }
 }
 ```
@@ -333,13 +333,13 @@ impl TimeMap {
         let Some(time_map) = self.key_store.get(&key) else {
             return String::new();
         };
-        let mut seen = 0;
+        let mut seen = -1;
         for &time in time_map.keys() {
             if time <= timestamp && time > seen {
                 seen = time;
             }
         }
-        if seen == 0 {
+        if seen == -1 {
             String::new()
         } else {
             time_map[&seen].last().unwrap().clone()

--- a/articles/top-k-elements-in-list.md
+++ b/articles/top-k-elements-in-list.md
@@ -392,29 +392,39 @@ public class Solution {
 ```
 
 ```go
+type MinHeap [][2]int
+
+func (h MinHeap) Len() int            { return len(h) }
+func (h MinHeap) Less(i, j int) bool  { return h[i][0] < h[j][0] }
+func (h MinHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MinHeap) Push(x interface{}) { *h = append(*h, x.([2]int)) }
+func (h *MinHeap) Pop() interface{} {
+    old := *h
+    n := len(old)
+    x := old[n-1]
+    *h = old[:n-1]
+    return x
+}
+
 func topKFrequent(nums []int, k int) []int {
     count := make(map[int]int)
     for _, num := range nums {
         count[num]++
     }
 
-    heap := priorityqueue.NewWith(func(a, b interface{}) int {
-        freqA := a.([2]int)[0]
-        freqB := b.([2]int)[0]
-        return utils.IntComparator(freqA, freqB)
-    })
+    minHeap := &MinHeap{}
+    heap.Init(minHeap)
 
     for num, freq := range count {
-        heap.Enqueue([2]int{freq, num})
-        if heap.Size() > k {
-            heap.Dequeue()
+        heap.Push(minHeap, [2]int{freq, num})
+        if minHeap.Len() > k {
+            heap.Pop(minHeap)
         }
     }
 
     res := make([]int, k)
     for i := k - 1; i >= 0; i-- {
-        value, _ := heap.Dequeue()
-        res[i] = value.([2]int)[1]
+        res[i] = heap.Pop(minHeap).([2]int)[1]
     }
     return res
 }

--- a/articles/trapping-rain-water.md
+++ b/articles/trapping-rain-water.md
@@ -796,28 +796,28 @@ func trap(height []int) int {
         return 0
     }
 
-    stack := linkedliststack.New()
+    stack := []int{}
     res := 0
 
     for i := 0; i < len(height); i++ {
-        for !stack.Empty() {
-            topIndex, _ := stack.Peek()
-            if height[i] >= height[topIndex.(int)] {
-                midIndex, _ := stack.Pop()
-                mid := height[midIndex.(int)]
-                if !stack.Empty() {
-                    topIndex, _ := stack.Peek()
+        for len(stack) > 0 {
+            topIndex := stack[len(stack)-1]
+            if height[i] >= height[topIndex] {
+                stack = stack[:len(stack)-1]
+                mid := height[topIndex]
+                if len(stack) > 0 {
+                    topIndex = stack[len(stack)-1]
                     right := height[i]
-                    left := height[topIndex.(int)]
+                    left := height[topIndex]
                     h := min(right, left) - mid
-                    w := i - topIndex.(int) - 1
+                    w := i - topIndex - 1
                     res += h * w
                 }
             } else {
                 break
             }
         }
-        stack.Push(i)
+        stack = append(stack, i)
     }
     return res
 }

--- a/articles/validate-parentheses.md
+++ b/articles/validate-parentheses.md
@@ -335,25 +335,26 @@ public class Solution {
 
 ```go
 func isValid(s string) bool {
-    stack := linkedliststack.New()
+    stack := []rune{}
     closeToOpen := map[rune]rune{')': '(', ']': '[', '}': '{'}
 
     for _, c := range s {
         if open, exists := closeToOpen[c]; exists {
-            if !stack.Empty() {
-                top, ok := stack.Pop()
-                if ok && top.(rune) != open {
+            if len(stack) > 0 {
+                top := stack[len(stack)-1]
+                stack = stack[:len(stack)-1]
+                if top != open {
                     return false
                 }
             } else {
                 return false
             }
         } else {
-            stack.Push(c)
+            stack = append(stack, c)
         }
     }
 
-    return stack.Empty()
+    return len(stack) == 0
 }
 ```
 


### PR DESCRIPTION
## Summary

A 4-runs-per-combo soak of every article approach × language across 72 problems against the live judge surfaced a set of deterministic (4/4) failures. This PR fixes all of them on the article side. It **includes #6039 (Go stdlib heap/stack rewrites) and #6044 (pow-x-n JS INT_MIN fix) as merges** — merging this PR marks both as merged — and adds one commit on top:

- **time-based-key-value-store — Brute Force, all 9 languages**: a value set at timestamp 0 could never be returned; the `seen` sentinel of `0` collided with a legal timestamp (site contract is `0 <= timestamp <= 10^7`). Sentinel is now `-1`. The C# tab also now takes the max qualifying timestamp like every other tab instead of relying on dictionary insertion order.
- **palindrome-partitioning — Rust `Recursion` and `Backtracking (DP)`**: the palindrome-table fill computed `i + l - 2`, which underflows `usize` at `l = 1, i = 0` and panics at runtime on every input (the judge saw empty output). Now computes `j = i + l - 1` guarded by `l <= 2`.
- **copy-linked-list-with-random-pointer — all 5 Rust tabs**: replaced the index-based placeholder stubs ("LeetCode does not support Rust") with real implementations against the judge's `Option<Rc<RefCell<Node>>>` type, including both O(1) extra-space interleaving variants.
- **kth-smallest-integer-in-bst — Kotlin `Morris Traversal`**: assigned through nullable receivers and did not compile; rewritten null-safely. **Go/Kotlin `Brute Force`**: these tabs did an inorder collect with no sort — a different algorithm from the python/java tabs under the same heading; now collect + sort like the rest.
- **longest-substring-without-duplicates**: the Swift Brute Force snippet was fenced as ```` ```kotlin ````, so kotlin appeared twice and swift had zero coverage.

## Verification

Every touched problem was run twice (three times for time-based-key-value-store) through `test-problem-article-solutions.ts` against the live judge — 20 problems, 41 runs total. All previously-failing deterministic combos now pass. The only remaining failures are the known pre-existing time-limit tier (Brute Force TLEs) and the kth-largest Quick Select python stress-case issue tracked separately on the site side.

Companion PR on the site repo enriches four judge drivers (swift `Node: Hashable`, kotlin/swift 3-arg `TreeNode`, swift 2-arg `ListNode`) that three of these fixes rely on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)