### PR TITLE
add(wiggle-sort): rust solution for 280-wiggle-sort

### DIFF
--- a/rust/0280-wiggle-sort.rs
+++ b/rust/0280-wiggle-sort.rs
@@ -1,0 +1,11 @@
+impl Solution {
+    pub fn wiggle_sort(nums: &mut Vec<i32>) {
+        for i in 1..nums.len() {
+            if (i % 2 == 0 && nums[i] > nums[i - 1]) || (i % 2 == 1 && nums[i] < nums[i - 1]) {
+                nums[i] ^= nums[i - 1];
+                nums[i - 1] ^= nums[i];
+                nums[i] ^= nums[i - 1];
+            }
+        }
+    }
+}


### PR DESCRIPTION
Created rust solution for the wiggle sort problem.

- **File(s) Modified**: _0280-wiggle-sort.rs_
- **Language(s) Used**: _rust_
- **Submission URL**: _TODO_

PS:- problem is premium on leetcode, so solved it on neetcode.